### PR TITLE
Extend semantic annotation indexing to include properties

### DIFF
--- a/src/main/resources/application-context-eml-annotation.xml
+++ b/src/main/resources/application-context-eml-annotation.xml
@@ -17,7 +17,7 @@
 			<list>
 				<bean class="org.dataone.cn.indexer.parser.SolrField">
 					<constructor-arg name="name" value="sem_annotation" />
-					<constructor-arg name="xpath" value="//annotation/valueURI/text()" />
+					<constructor-arg name="xpath" value="//annotation/propertyURI/text() | //annotation/valueURI/text()" />
 					<constructor-arg name="multivalue" value="true" />
 				</bean>
 			</list>

--- a/src/main/resources/application-context-ontology-model-service.xml
+++ b/src/main/resources/application-context-ontology-model-service.xml
@@ -6,7 +6,8 @@
 	<bean id="ontologyModelService" class="org.dataone.cn.indexer.annotation.OntologyModelService">
 		<property name="fieldList">
 			<list>
-				<ref bean="eml.annotation.expansion" />
+				<ref bean="eml.annotation.property.expansion" />
+				<ref bean="eml.annotation.value.expansion" />
 			</list>
 		</property>
 
@@ -57,8 +58,8 @@
 		</constructor-arg>
 	</bean>
 
-	<bean id="eml.annotation.expansion" class="org.dataone.cn.indexer.annotation.SparqlField">
-		<constructor-arg name="name" value="sem_annotation" />
+	<bean id="eml.annotation.property.expansion" class="org.dataone.cn.indexer.annotation.SparqlField">
+		<constructor-arg name="name" value="annotation_property_uri" />
 		<constructor-arg name="query">
 			<value>
 				<![CDATA[
@@ -66,9 +67,27 @@
 				PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 				PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
-				SELECT ?sem_annotation
+				SELECT ?annotation_property_uri
 				WHERE {
-						<$CONCEPT_URI> rdfs:subClassOf* ?sem_annotation .
+						<$CONCEPT_URI> rdfs:subPropertyOf* ?annotation_property_uri .
+				 	}
+				 ]]>
+			</value>
+		</constructor-arg>
+	</bean>
+
+	<bean id="eml.annotation.value.expansion" class="org.dataone.cn.indexer.annotation.SparqlField">
+		<constructor-arg name="name" value="annotation_value_uri" />
+		<constructor-arg name="query">
+			<value>
+				<![CDATA[
+				PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+				PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+				PREFIX owl: <http://www.w3.org/2002/07/owl#>
+
+				SELECT ?annotation_value_uri
+				WHERE {
+						<$CONCEPT_URI> rdfs:subClassOf* ?annotation_value_uri .
 				 	}
 				 ]]>
 			</value>

--- a/src/test/java/org/dataone/cn/indexer/annotation/EmlAnnotationSubprocessorTest.java
+++ b/src/test/java/org/dataone/cn/indexer/annotation/EmlAnnotationSubprocessorTest.java
@@ -62,9 +62,11 @@ public class EmlAnnotationSubprocessorTest {
 
             expectedConcepts.add("http://purl.dataone.org/odo/ECSO_00000512");
             expectedConcepts.add("http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#MeasurementType");
+            expectedConcepts.add("http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#hasUnit");
             expectedConcepts.add("http://purl.dataone.org/odo/ECSO_00001102");
             expectedConcepts.add("http://purl.dataone.org/odo/ECSO_00001243");
             expectedConcepts.add("http://purl.dataone.org/odo/ECSO_00000629");
+            expectedConcepts.add("http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#containsMeasurementsOfType");
             expectedConcepts.add("http://purl.dataone.org/odo/ECSO_00000518");
             expectedConcepts.add("http://www.w3.org/2000/01/rdf-schema#Resource");
             expectedConcepts.add("http://purl.dataone.org/odo/ECSO_00000516");

--- a/src/test/java/org/dataone/cn/indexer/annotation/OntologyModelServiceTest.java
+++ b/src/test/java/org/dataone/cn/indexer/annotation/OntologyModelServiceTest.java
@@ -29,13 +29,15 @@ public class OntologyModelServiceTest {
 
 			// Assert on Solr fields returend
 			Set<String> fields = new HashSet<String>();
-			fields.add("sem_annotation");
+			fields.add("annotation_property_uri");
+			fields.add("annotation_value_uri");
 			assertEquals(concepts.keySet(), fields);
 
 			// Assert on Solr field values returned
 			Set<String> values = new HashSet<String>();
 			values.add("https://example.org");
-			assertEquals(values, concepts.get("sem_annotation"));
+			assertEquals(values, concepts.get("annotation_property_uri"));
+			assertEquals(values, concepts.get("annotation_value_uri"));
 		} catch (Exception e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -53,7 +55,8 @@ public class OntologyModelServiceTest {
 
 			// Assert on Solr fields returend
 			Set<String> fields = new HashSet<String>();
-			fields.add("sem_annotation");
+			fields.add("annotation_property_uri");
+			fields.add("annotation_value_uri");
 			assertEquals(concepts.keySet(), fields);
 
 			// Assert on Solr field values returned
@@ -65,7 +68,25 @@ public class OntologyModelServiceTest {
 			values.add("http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#MeasurementType");
 			values.add("http://www.w3.org/2000/01/rdf-schema#Resource");
 
-			assertEquals(values, concepts.get("sem_annotation"));
+			assertEquals(values, concepts.get("annotation_value_uri"));
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testPropertyExpansion() {
+		try {
+			Map<String, Set<String>> concepts = OntologyModelService.getInstance().expandConcepts("http://purl.obolibrary.org/obo/RO_0002352");
+
+			Set<String> values = new HashSet<String>();
+			values.add("http://purl.obolibrary.org/obo/RO_0002328");
+			values.add("http://purl.obolibrary.org/obo/RO_0002352");
+			values.add("http://purl.obolibrary.org/obo/RO_0000056");
+
+			assertEquals(values, concepts.get("annotation_property_uri"));
 		} catch (Exception e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();

--- a/src/test/java/org/dataone/cn/indexer/annotation/SolrFieldEmlAnnotationTest.java
+++ b/src/test/java/org/dataone/cn/indexer/annotation/SolrFieldEmlAnnotationTest.java
@@ -73,7 +73,10 @@ public class SolrFieldEmlAnnotationTest extends BaseSolrFieldXPathTest {
             "http://purl.dataone.org/odo/ECSO_00000518" + "||" +
             "http://www.w3.org/2000/01/rdf-schema#Resource" + "||" +
             "http://purl.dataone.org/odo/ECSO_00000516" + "||" +
-            "http://purl.obolibrary.org/obo/UO_0000301");
+            "http://purl.obolibrary.org/obo/UO_0000301" + "||" +
+            "http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#hasUnit" + "||" +
+            "http://purl.dataone.org/odo/ECSO_00000629" + "||" +
+            "http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#containsMeasurementsOfType");
     }
 
     protected boolean compareFields(HashMap<String, String> expected, InputStream document,


### PR DESCRIPTION
Closes https://github.com/DataONEorg/d1_cn_index_processor/issues/27

This change will require reindexing of affected content

A similar change was made to Metacat https://github.com/NCEAS/metacat/issues/1517