### PR TITLE
Fix http repository issues in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,12 +32,29 @@
     </repository>
 	<repository>
 		<id>dataone.org</id>
-		<url>http://maven.dataone.org</url>
+		<url>https://maven.dataone.org</url>
 		<releases>
 		    <enabled>true</enabled>
 		</releases>
 		<snapshots>
 		    <enabled>true</enabled>
+		</snapshots>
+	</repository>
+	<!--
+		2021-09-24 <mecum@nceas.ucsb.edu>
+
+		Remove this eventually: http->https mirror for maven.restlet that we can
+		remove once we update solr-core to a version that doesn't have the http
+		repository for restlet.
+	-->
+	<repository>
+		<id>maven-restlet</id>
+		<url>https://maven.restlet.org</url>
+		<releases>
+			<enabled>true</enabled>
+		</releases>
+		<snapshots>
+			<enabled>true</enabled>
 		</snapshots>
 	</repository>
  </repositories>


### PR DESCRIPTION
With the tip of `develop_2.3` and Maven 3.8.2, I get the following error on a `mvn install`:

> [ERROR] Failed to execute goal on project d1_cn_index_processor: Could not resolve dependencies for project org.dataone:d1_cn_index_processor:jar:2.4.0-SNAPSHOT: Failed to collect dependencies at org.apache.solr:solr-core:jar:5.2.1 -> org.restlet.jee:org.restlet:jar:2.3.0: Failed to read artifact descriptor for org.restlet.jee:org.restlet:jar:2.3.0: Could not transfer artifact org.restlet.jee:org.restlet:pom:2.3.0 from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [maven-restlet (http://maven.restlet.org, default, releases+snapshots), apache.snapshots (http://repository.apache.org/snapshots, default, disabled)] -> [Help 1]

Maven deprecated the use of non-https repository URLs in 3.8.1 and the build fails seemingly because of that. I guess restlet is a transitive dependency here and solr-core 5.2.1 references it via a non-https URL. While this check can be disabled locally, I think it's way better if our code just `mvn $whatever`s cleanly. I bet we can also work around this by upgrading solr-core as I assume they must've fixed this some time in the last few major versions (we're on a 2015 build).

This changes our dataone maven repo to use https and puts in an override mirror for for Restlet since the POM for the version of solr-core we use appears to include a link to the *http* restlet mirror. 

@taojing2002 I PR'd this so you could make sure this isn't just a setup issue on my system and so you could confirm the error I see above happens for you without this patch. Could you take a look?

