### PR TITLE
Add MOSAIC, ARCRC, SENSO, ADCAD, SALMON expand query expansion rules

### DIFF
--- a/src/main/resources/application-context-ontology-model-service.xml
+++ b/src/main/resources/application-context-ontology-model-service.xml
@@ -85,11 +85,12 @@
 				PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 				PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 				PREFIX owl: <http://www.w3.org/2002/07/owl#>
+				PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
 				SELECT ?annotation_value_uri
 				WHERE
 				{
-					<$CONCEPT_URI> (rdf:type|owl:equivalentClass*|(owl:sameAs|^owl:sameAs)*)/rdfs:subClassOf* ?annotation_value_uri  .
+					<$CONCEPT_URI> (rdf:type|(owl:equivalentClass|^owl:equivalentClass)*|(owl:sameAs|^owl:sameAs)*|(skos:exactMatch|^skos:exactMatch)*)/rdfs:subClassOf* ?annotation_value_uri  .
 				}
 				]]>
 			</value>

--- a/src/main/resources/application-context-ontology-model-service.xml
+++ b/src/main/resources/application-context-ontology-model-service.xml
@@ -87,10 +87,11 @@
 				PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 				SELECT ?annotation_value_uri
-				WHERE {
-						<$CONCEPT_URI> rdfs:subClassOf* ?annotation_value_uri .
-				 	}
-				 ]]>
+				WHERE
+				{
+					<$CONCEPT_URI> (rdf:type|owl:equivalentClass*|(owl:sameAs|^owl:sameAs)*)/rdfs:subClassOf* ?annotation_value_uri  .
+				}
+				]]>
 			</value>
 		</constructor-arg>
 	</bean>

--- a/src/main/resources/application-context-ontology-model-service.xml
+++ b/src/main/resources/application-context-ontology-model-service.xml
@@ -28,6 +28,11 @@
 				<value>http://ecoinformatics.org/oboe-ext/sbclter.1.0/oboe-sbclter.owl</value>
 				<value>https://purl.dataone.org/odo/MOSAIC_</value>
 				<value>http://purl.dataone.org/odo/ARCRC</value>
+				<value>https://purl.dataone.org/odo/ADCAD_</value>
+				<value>http://purl.dataone.org/odo/SENSO_</value>
+				<value>http://purl.dataone.org/odo/SALMON_</value>
+				<value>http://purl.dataone.org/odo/SALMON_alignment_</value>
+				<value>http://purl.dataone.org/odo/SASAP_</value>
 			</list>
 		</property>
 
@@ -55,6 +60,11 @@
 				<entry key="http://ecoinformatics.org/oboe-ext/sbclter.1.0/oboe-sbclter.owl" value="file:src/main/resources/ontologies/oboe-sbclter.owl" />
 				<entry key="https://purl.dataone.org/odo/MOSAIC_" value="file:src/main/resources/ontologies/MOSAiC.owl" />
 				<entry key="http://purl.dataone.org/odo/ARCRC" value="file:src/main/resources/ontologies/ARCRC.owl" />
+				<entry key="https://purl.dataone.org/odo/ADCAD_" value="file:src/main/resources/ontologies/ADCAD.owl" />
+				<entry key="http://purl.dataone.org/odo/SENSO_" value="file:src/main/resources/ontologies/SENSO.owl" />
+				<entry key="http://purl.dataone.org/odo/SALMON_" value="file:src/main/resources/ontologies/SALMON.owl" />
+				<entry key="http://purl.dataone.org/odo/SALMON_alignment_" value="file:src/main/resources/ontologies/SALMON_alignment.owl" />
+				<entry key="http://purl.dataone.org/odo/SASAP_" value="file:src/main/resources/ontologies/SASAP.owl" />
 			</map>
 		</constructor-arg>
 	</bean>

--- a/src/main/resources/application-context-ontology-model-service.xml
+++ b/src/main/resources/application-context-ontology-model-service.xml
@@ -70,7 +70,7 @@
 
 				SELECT ?annotation_property_uri
 				WHERE {
-						<$CONCEPT_URI> rdfs:subPropertyOf* ?annotation_property_uri .
+						<$CONCEPT_URI> (owl:equivalentProperty|^owl:equivalentProperty)*/rdfs:subPropertyOf* ?annotation_property_uri .
 				 	}
 				 ]]>
 			</value>

--- a/src/main/resources/application-context-ontology-model-service.xml
+++ b/src/main/resources/application-context-ontology-model-service.xml
@@ -1,7 +1,4 @@
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="ontologyModelService" class="org.dataone.cn.indexer.annotation.OntologyModelService">
 		<property name="fieldList">
@@ -11,7 +8,7 @@
 			</list>
 		</property>
 
-	    <property name="ontologyList">
+		<property name="ontologyList">
 			<list>
 				<value>http://purl.dataone.org/ontologies/observation/d1-ECSO.owl</value>
 				<value>http://purl.dataone.org/ontologies/provenance/ProvONE/v1/owl/provone.owl</value>
@@ -29,6 +26,8 @@
 				<value>http://ecoinformatics.org/oboe/oboe.1.2/oboe-chemistry.owl</value>
 				<value>http://ecoinformatics.org/oboe/oboe.1.2/oboe-anatomy.owl</value>
 				<value>http://ecoinformatics.org/oboe-ext/sbclter.1.0/oboe-sbclter.owl</value>
+				<value>https://purl.dataone.org/odo/MOSAIC_</value>
+				<value>http://purl.dataone.org/odo/ARCRC</value>
 			</list>
 		</property>
 
@@ -37,24 +36,26 @@
 
 	<bean id="alt.entries" class="java.util.HashMap">
 		<constructor-arg>
-				<map key-type="java.lang.String" value-type="java.lang.String">
-					<entry key="http://purl.dataone.org/ontologies/observation/d1-ECSO.owl" value="file:src/main/resources/ontologies/ECSO.owl" />
-					<entry key="http://purl.dataone.org/ontologies/provenance/ProvONE/v1/owl/provone.owl" value="file:src/main/resources/ontologies/provone.owl" />
-					<entry key="http://purl.obolibrary.org/obo/envo.owl" value="file:src/main/resources/ontologies/envo.owl" />
-					<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-owl.owl" value="file:src/main/resources/ontologies/oboe.owl" />
-					<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl" value="file:src/main/resources/ontologies/oboe-core.owl" />
-					<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-characteristics.owl" value="file:src/main/resources/ontologies/oboe-characteristics.owl" />
-					<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-standards.owl" value="file:src/main/resources/ontologies/oboe-standards.owl" />
-					<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-spatial.owl" value="file:src/main/resources/ontologies/oboe-spatial.owl" />
-					<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-temporal.owl" value="file:src/main/resources/ontologies/oboe-temporal.owl" />
-					<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-taxa.owl" value="file:src/main/resources/ontologies/oboe-taxa.owl" />
-					<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-biology.owl" value="file:src/main/resources/ontologies/oboe-biology.owl" />
-					<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-ecology.owl" value="file:src/main/resources/ontologies/oboe-ecology.owl" />
-					<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-environment.owl" value="file:src/main/resources/ontologies/oboe-environment.owl" />
-					<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-chemistry.owl" value="file:src/main/resources/ontologies/oboe-chemistry.owl" />
-					<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-anatomy.owl" value="file:src/main/resources/ontologies/oboe-anatomy.owl" />
-					<entry key="http://ecoinformatics.org/oboe-ext/sbclter.1.0/oboe-sbclter.owl" value="file:src/main/resources/ontologies/oboe-sbclter.owl" />
-				</map>
+			<map key-type="java.lang.String" value-type="java.lang.String">
+				<entry key="http://purl.dataone.org/ontologies/observation/d1-ECSO.owl" value="file:src/main/resources/ontologies/ECSO.owl" />
+				<entry key="http://purl.dataone.org/ontologies/provenance/ProvONE/v1/owl/provone.owl" value="file:src/main/resources/ontologies/provone.owl" />
+				<entry key="http://purl.obolibrary.org/obo/envo.owl" value="file:src/main/resources/ontologies/envo.owl" />
+				<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-owl.owl" value="file:src/main/resources/ontologies/oboe.owl" />
+				<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl" value="file:src/main/resources/ontologies/oboe-core.owl" />
+				<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-characteristics.owl" value="file:src/main/resources/ontologies/oboe-characteristics.owl" />
+				<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-standards.owl" value="file:src/main/resources/ontologies/oboe-standards.owl" />
+				<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-spatial.owl" value="file:src/main/resources/ontologies/oboe-spatial.owl" />
+				<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-temporal.owl" value="file:src/main/resources/ontologies/oboe-temporal.owl" />
+				<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-taxa.owl" value="file:src/main/resources/ontologies/oboe-taxa.owl" />
+				<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-biology.owl" value="file:src/main/resources/ontologies/oboe-biology.owl" />
+				<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-ecology.owl" value="file:src/main/resources/ontologies/oboe-ecology.owl" />
+				<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-environment.owl" value="file:src/main/resources/ontologies/oboe-environment.owl" />
+				<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-chemistry.owl" value="file:src/main/resources/ontologies/oboe-chemistry.owl" />
+				<entry key="http://ecoinformatics.org/oboe/oboe.1.2/oboe-anatomy.owl" value="file:src/main/resources/ontologies/oboe-anatomy.owl" />
+				<entry key="http://ecoinformatics.org/oboe-ext/sbclter.1.0/oboe-sbclter.owl" value="file:src/main/resources/ontologies/oboe-sbclter.owl" />
+				<entry key="https://purl.dataone.org/odo/MOSAIC_" value="file:src/main/resources/ontologies/MOSAiC.owl" />
+				<entry key="http://purl.dataone.org/odo/ARCRC" value="file:src/main/resources/ontologies/ARCRC.owl" />
+			</map>
 		</constructor-arg>
 	</bean>
 

--- a/src/main/resources/ontologies/ADCAD.owl
+++ b/src/main/resources/ontologies/ADCAD.owl
@@ -1,0 +1,481 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:terms="http://purl.org/dc/terms/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:obo="http://purl.obolibrary.org/obo/"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:wikidata="https://www.wikidata.org/wiki/"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:plos="http://localhost/plosthes.2017-1#"
+    xmlns:odo="https://purl.dataone.org/odo/"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#" > 
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00071">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q43455"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00004"/>
+    <rdfs:label>Ethnology</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00031">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q9161265"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#5560"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00038"/>
+    <rdfs:label>Soil Science</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00075">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q8078"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00068"/>
+    <rdfs:label>Logic</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00063">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q2374463"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00068"/>
+    <rdfs:label>Data science</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00068">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q816264"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00000"/>
+    <rdfs:label>Formal Science</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00056">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q43035"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#3462"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00050"/>
+    <rdfs:label>Electrical Engineering</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00044">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q161764"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#4377"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00038"/>
+    <rdfs:label>Geochemistry</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00000">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q11862829"/>
+    <rdfs:label>Academic Discipline</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00076">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q8162"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#4752"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00004"/>
+    <rdfs:label>Linguistics</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_">
+    <owl:versionInfo>Version 1.0.0</owl:versionInfo>
+    <owl:versionIRI rdf:resource="https://purl.dataone.org/odo/ADCAD/1.0.0"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
+    <terms:title>Arctic Data Center Academic Disciplines Ontology (ADCAD)</terms:title>
+    <terms:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
+    <terms:description>Ontology to support disciplinary annotation of datasets housed at the Arctic Data Center (https://arcticdata.io)</terms:description>
+    <terms:creator rdf:resource="https://orcid.org/0000-0003-0077-4738"/>
+    <terms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-12-09</terms:created>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00032">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q19924411"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#1816"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00010"/>
+    <rdfs:label>Forestry</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00028">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q207011"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#3301"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00010"/>
+    <rdfs:label>Neuroscience</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00016">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q908902"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00010"/>
+    <rdfs:label>Structural Biology</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00004">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q34749"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#8539"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00000"/>
+    <rdfs:label>Social Science</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00036">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q333"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#4331"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00033"/>
+    <rdfs:label>Astronomy</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00008">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q36442"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#3078"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00004"/>
+    <rdfs:label>Political Science</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00082">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q47041"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#4462"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00010"/>
+    <rdfs:label>Biodiversity</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00070">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q2419229"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#5253"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00010"/>
+    <rdfs:label>Theoretical Biology</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00042">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q46255"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#2002"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00038"/>
+    <rdfs:label>Geophysics</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00030">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q3606845"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#7452"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00010"/>
+    <rdfs:label>Agricultural Research</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00074">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q101333"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#713"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00050"/>
+    <rdfs:label>Mechanical Engineering</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00062">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q1450531"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00050"/>
+    <rdfs:label>Cyberinfrastructure</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00050">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q11023"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#4019"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00000"/>
+    <rdfs:label>Engineering</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00035">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q413"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#6066"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00033"/>
+    <rdfs:label>Physics</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00079">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q52120"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#7901"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00080"/>
+    <rdfs:label>Glaciology</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00023">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q7150"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#10424"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00010"/>
+    <rdfs:label>Ecology</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00067">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q7991"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00000"/>
+    <rdfs:label>Natural Science</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00055">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q682496"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#1866"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00050"/>
+    <rdfs:label>Systems Engineering</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00043">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q131089"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#2110"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00038"/>
+    <rdfs:label>Geodesy</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00039">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q757520"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#4730"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00038"/>
+    <rdfs:label>Atmospheric Science</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00027">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q133805"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#8910"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00010"/>
+    <rdfs:label>Epidemiology</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00015">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q7141"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#1352"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00010"/>
+    <rdfs:label>Cell Biology</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00003">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q23498"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#2668"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00004"/>
+    <rdfs:label>Archaeology</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00019">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q128570"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#3739"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00010"/>
+    <rdfs:label>Bioinformatics</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00081">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q166542"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#1449"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00008"/>
+    <rdfs:label>International Relations</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00053">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q228736"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#8251"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00050"/>
+    <rdfs:label>Materials Science</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00041">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q1069"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#7981"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00038"/>
+    <rdfs:label>Geology</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00073">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q77590"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#8418"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00050"/>
+    <rdfs:label>Civil Engineering</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00078">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q12831143"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#7999"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00004"/>
+    <rdfs:label>Human Geography</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00034">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q2329"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#2863"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00033"/>
+    <rdfs:label>Chemistry</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00022">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q431"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#5402"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00010"/>
+    <rdfs:label>Zoology</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00066">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q840400"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#9401"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00010"/>
+    <rdfs:label>Evolutionary Biology</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00010">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q864928"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#3625"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00067"/>
+    <rdfs:label>Life Science</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00006">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q9418"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#6810"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00004"/>
+    <rdfs:label>Psychology</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00038">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q8008"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#1990"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00033"/>
+    <rdfs:label>Geoscience</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00014">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q7100"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#1443"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00010"/>
+    <rdfs:label>Biophysics</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00058">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q80993"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#2352"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00050"/>
+    <rdfs:label>Software Engineering</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00018">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q213713"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#4415"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00010"/>
+    <rdfs:label>Developmental Biology</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00080">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q2383547"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00049"/>
+    <rdfs:label>Cryology</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00064">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q12483"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#5750"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00068"/>
+    <rdfs:label>Statistics</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00020">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q514"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#1761"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00010"/>
+    <rdfs:label>Anatomy</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00052">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q1710723"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00050"/>
+    <rdfs:label>Materials Engineering</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00040">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q43518"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#6456"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00038"/>
+    <rdfs:label>Oceanography</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00072">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q83588"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#8050"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00050"/>
+    <rdfs:label>Chemical Engineering</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00057">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q21198"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#2884"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00068"/>
+    <rdfs:label>Computer Science</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00013">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q7094"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#2243"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00010"/>
+    <rdfs:label>Biochemistry</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00045">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q52107"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#10439"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00038"/>
+    <rdfs:label>Physical Geography</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00077">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q21201"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#4823"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00004"/>
+    <rdfs:label>Sociology</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00033">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q14632398"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#3917"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00067"/>
+    <rdfs:label>Physical Science</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00065">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q23404"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#2187"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00004"/>
+    <rdfs:label>Anthropology</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00021">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q441"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#6638"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00010"/>
+    <rdfs:label>Plant Science</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00017">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q7162"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#6195"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00010"/>
+    <rdfs:label>Genetics</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00049">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q42250"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#9617"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00038"/>
+    <rdfs:label>Hydrology</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00005">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q8434"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#4484"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00004"/>
+    <rdfs:label>Education</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00037">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q395"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#9313"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00068"/>
+    <rdfs:label>Mathematics</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00069">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q7205"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#2848"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00038"/>
+    <rdfs:label>Palaeontology</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00025">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q7193"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#3803"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00010"/>
+    <rdfs:label>Microbiology</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.dataone.org/odo/ADCAD_00009">
+    <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q8134"/>
+    <skos:exactMatch rdf:resource="http://localhost/plosthes.2017-1#1"/>
+    <rdfs:subClassOf rdf:resource="https://purl.dataone.org/odo/ADCAD_00004"/>
+    <rdfs:label>Economics</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/src/main/resources/ontologies/ARCRC.owl
+++ b/src/main/resources/ontologies/ARCRC.owl
@@ -1,0 +1,1116 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://www.semanticweb.org/samanthacsik/ontologies/2020/10/untitled-ontology-48#"
+     xml:base="http://www.semanticweb.org/samanthacsik/ontologies/2020/10/untitled-ontology-48"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:odo="http://purl.obolibrary.org/odo/"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:envo="http://purl.obolibrary.org/obo/envo#"
+     xmlns:foaf="http://xmlns.com/foaf/0.1/"
+     xmlns:odo1="http://purl.dataone.org/odo/"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+     xmlns:terms="http://purl.org/dc/terms/"
+     xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
+    <owl:Ontology rdf:about="http://purl.dataone.org/odo/ARCRC">
+        <owl:versionIRI rdf:resource="http://purl.dataone.org/odo/ARCRC.owl/0.9"/>
+        <owl:imports rdf:resource="http://purl.dataone.org/odo/ECSO8.owl"/>
+        <owl:imports rdf:resource="http://www.opengis.net/ont/geosparql"/>
+    </owl:Ontology>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-04T19:46:54Z</dc:date>
+        <rdfs:label xml:lang="en">definition</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/odo/IAO_0000119 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/odo/IAO_0000119">
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-04T19:47:37Z</dc:date>
+        <rdfs:label xml:lang="en">definition source</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/creator -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/creator"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/date -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/date"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/description -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/description"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#id -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#id"/>
+    
+
+
+    <!-- http://www.w3.org/2000/01/rdf-schema#comment -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#comment"/>
+    
+
+
+    <!-- http://www.w3.org/2002/07/owl#sameAs -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2002/07/owl#sameAs"/>
+    
+
+
+    <!-- http://www.w3.org/2004/02/skos/core#altLabel -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000011 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.dataone.org/odo/ARCRC_00000011">
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-04T22:51:54Z</dc:date>
+        <rdfs:comment>might want to delete before we import ECSO so that there are no conflict issues (usesProtocol already exists in ECSO)</rdfs:comment>
+        <rdfs:label xml:lang="en">usesProtocol</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000012 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.dataone.org/odo/ARCRC_00000012">
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-04T22:53:03Z</dc:date>
+        <rdfs:comment>adding this object property, but can delete later if not appropriate
+
+e.g. of usage for NSIDC sea ice index (a target variable) that is calculated using both ice extent and ice concentration data:
+
+axiom = calculatedUsing only (Sea Ice Extent and Sea Ice Concentration)</rdfs:comment>
+        <rdfs:label xml:lang="en">calculatedUsing</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000518 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.dataone.org/odo/ARCRC_00000518"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000000 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000000">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000504"/>
+        <obo:IAO_0000115>Vital Signs are indicators of the state of the Arctic environmental system. They are assessed using measurements of and/or proxies for target variables.</obo:IAO_0000115>
+        <odo:IAO_0000119>inferred from https://arctic.noaa.gov/Report-Card</odo:IAO_0000119>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-04T19:24:38Z</dc:date>
+        <dc:description>Issued annually since 2006, the Arctic Report Card (ARC) is a timely and peer-reviewed source for clear, reliable and concise environmental information on the current state of different components of the Arctic environmental system relative to historical records. The Report Card is intended for a wide audience, including scientists, teachers, students, decision-makers and the general public interested in the Arctic environment and science.</dc:description>
+        <rdfs:label xml:lang="en">Arctic Essays 2020</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000001 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000001">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000013"/>
+        <obo:IAO_0000115>Snow covering the Arctic land surface, which is characterized by three variables: snow cover extent (how much area is covered by snow), snow cover duration (how long snow continuously remains on the land surface), and snow water equivalent (how much water is stored in solid form by the snowpack; a function of snow depth and density).</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-04T19:42:36Z</dc:date>
+        <rdfs:label xml:lang="en">Terrestrial Snow Cover Indicator</rdfs:label>
+        <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/ECSO_00001652"/>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/ARCRC_00000001"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Snow covering the Arctic land surface, which is characterized by three variables: snow cover extent (how much area is covered by snow), snow cover duration (how long snow continuously remains on the land surface), and snow water equivalent (how much water is stored in solid form by the snowpack; a function of snow depth and density).</owl:annotatedTarget>
+        <odo:IAO_0000119>adapted from https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/843/Terrestrial-Snow-Cover</odo:IAO_0000119>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000002 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000002">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000013"/>
+        <obo:IAO_0000115>The quantity of aboveground vegetation in the Arctic tundra.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-04T19:42:42Z</dc:date>
+        <rdfs:label xml:lang="en">Tundra Greenness Indicator</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/ARCRC_00000002"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>The quantity of aboveground vegetation in the Arctic tundra.</owl:annotatedTarget>
+        <dc:description>Normalized Difference Vegetation Index, NDVI (http://www.purl.dataone.org/odo/ECSO_00010076) is highly correlated with Tundra Greeness.</dc:description>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000003 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000003">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000013"/>
+        <obo:IAO_0000115>An air temperature measured two-meters above the land or ocean surface.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-04T19:42:51Z</dc:date>
+        <rdfs:label xml:lang="en">Surface Air Temperature Indicator</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000004 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000004">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000013"/>
+        <obo:IAO_0000115>A vast body of ice covering 1.71 million km2, roughly 80% of the surface of Greenland.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <rdfs:label>Greenland Ice Sheet Indicator</rdfs:label>
+        <rdfs:seeAlso>https://nsidc.org/cryosphere/glossary/</rdfs:seeAlso>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000005 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000005">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000013"/>
+        <obo:IAO_0000115>The process of carbon fixation in the Arctic Ocean, primarily by autotrophic single-celled algae living in sea ice (ice algae) and water column (phytoplankton).</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-04T19:43:13Z</dc:date>
+        <rdfs:label xml:lang="en">Arctic Ocean Primary Productivity Indicator</rdfs:label>
+        <skos:altLabel>Arctic Ocean Primary Productivity Carbon Flux</skos:altLabel>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000006 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000006">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000013"/>
+        <obo:IAO_0000115>A water temperature which inheres in water close to the surface of an ocean or sea. The exact meaning of surface varies according to the measurement method used, but it is between 1 millimetre (0.04 in) and 20 metres (70 ft) below the sea surface.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-04T19:43:19Z</dc:date>
+        <rdfs:label xml:lang="en">Sea Surface Temperature Indicator</rdfs:label>
+        <owl:sameAs>http://purl.dataone.org/odo/ECSO_00001523</owl:sameAs>
+        <skos:altLabel>SST
+temperature of sea surface
+ocean surface temperature
+temperature of the ocean surface</skos:altLabel>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000007 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000007">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000013"/>
+        <obo:IAO_0000115>Ice which has formed by the freezing of sea (saline) water.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-04T19:43:23Z</dc:date>
+        <rdfs:label xml:lang="en">Sea Ice Indicator</rdfs:label>
+        <owl:sameAs>http://purl.obolibrary.org/obo/ENVO_00002200</owl:sameAs>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000009 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000009">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000040"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000010 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000010">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000500"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-03T22:29:42Z</dc:date>
+        <rdfs:label xml:lang="en">Arctic Report Card Supporting Dataset</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000013 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000013">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000510"/>
+        <obo:IAO_0000115>Vital Signs are indicators of the state of the Arctic environmental system. They are assessed using measurements of and/or proxies for Key Variables.</obo:IAO_0000115>
+        <odo:IAO_0000119>inferred from https://arctic.noaa.gov/Report-Card</odo:IAO_0000119>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T00:43:25Z</dc:date>
+        <rdfs:label xml:lang="en">Arctic Vital Signs</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/ARCRC_00000013"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Vital Signs are indicators of the state of the Arctic environmental system. They are assessed using measurements of and/or proxies for Key Variables.</owl:annotatedTarget>
+        <dc:description>Issued annually since 2006, the Arctic Report Card is a timely and peer-reviewed source for clear, reliable and concise environmental information on the current state of different components of the Arctic environmental system relative to historical records. The Report Card is intended for a wide audience, including scientists, teachers, students, decision-makers and the general public interested in the Arctic environment and science.
+
+Find current and past assessments of the Arctic Report Card Vital Signs by visiting: https://arctic.noaa.gov/Report-Card</dc:description>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000014 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000014">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000010"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-03T22:30:07Z</dc:date>
+        <rdfs:label xml:lang="en">Arctic Report Card Supporting Dataset for the 2020 Report</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000040 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000040">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000500"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:04:20Z</dc:date>
+        <dc:description>Measurements and/or proxies used in the assessments of Arctic Report Card Essays.</dc:description>
+        <rdfs:label xml:lang="en">Arctic Key Variable</rdfs:label>
+        <skos:altLabel>Arctic Target Variables</skos:altLabel>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000041 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000041">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000504"/>
+        <obo:IAO_0000115>Measurements and/or proxies for assessing the 2020 Arctic Vital Signs.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:04:37Z</dc:date>
+        <rdfs:label xml:lang="en">Arctic Key Variables 2020</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000042 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000042">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000040"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000043 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000043">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000040"/>
+        <obo:IAO_0000115>The height of a given point in the atmosphere in units proportional to the potential energy of unit mass (geopotential) at this height relative to sea level.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:06:48Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Surface Air Temperature.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/835/Surface-Air-Temperature</dc:description>
+        <rdfs:label xml:lang="en">geopotential height</rdfs:label>
+        <skos:altLabel>geopotential altitude</skos:altLabel>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000044 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000044">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000040"/>
+        <obo:IAO_0000115>The sum of mean monthly Land Surface Temperatures (LST) for months with mean temperatures above freezing (&gt;0°C).</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:07:00Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Tundra Greenness.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/838/Tundra-Greenness</dc:description>
+        <rdfs:label xml:lang="en">Summer Warmth Index</rdfs:label>
+        <skos:altLabel>SWI</skos:altLabel>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000045 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000045">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000503"/>
+        <obo:IAO_0000115>Air temperature measured two-meters above the land or ocean surface.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:07:17Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Surface Air Temperature.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/835/Surface-Air-Temperature</dc:description>
+        <rdfs:label xml:lang="en">surface air temperature</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000046 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000046">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000040"/>
+        <obo:IAO_0000115>An air temperature measured in the lower troposphere (i.e. at 925 hPa).</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:08:13Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Surface Air Temperature.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/835/Surface-Air-Temperature</dc:description>
+        <rdfs:label xml:lang="en">near-surface air temperature</rdfs:label>
+        <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/ECSO_00003057"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000047 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000047">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000503"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000048 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000048">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000040"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000049 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000049">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000502"/>
+        <obo:IAO_0000115>How much area is covered in snow.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:10:34Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Terrestrial Snow Cover.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/843/Terrestrial-Snow-Cover</dc:description>
+        <rdfs:label xml:lang="en">snow cover extent</rdfs:label>
+        <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/ECSO_00001652"/>
+        <skos:altLabel>SCE</skos:altLabel>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000050 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000050">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000502"/>
+        <obo:IAO_0000115>How long snow continuously remains on land surfaces.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:10:49Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Terrestrial Snow Cover.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/843/Terrestrial-Snow-Cover</dc:description>
+        <rdfs:label xml:lang="en">snow cover duration</rdfs:label>
+        <skos:altLabel>SCD</skos:altLabel>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000051 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000051">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000502"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000053 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000053">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000501"/>
+        <obo:IAO_0000115>The fractional area coverage of sea ice over a given region.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:11:30Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Sea Ice.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/841/Sea-Ice</dc:description>
+        <rdfs:label xml:lang="en">sea ice concentration</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000054 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000054">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000501"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000055 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000055">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000501"/>
+        <obo:IAO_0000115>The total volume of sea ice (sea ice thickness multiplied by sea ice concentration) integrated over a given area.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:12:03Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Sea Ice.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/841/Sea-Ice</dc:description>
+        <rdfs:label xml:lang="en">sea ice volume</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000056 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000056">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000501"/>
+        <obo:IAO_0000115>The distance between the bottom of the ice to the top surface of the ice.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:12:13Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Sea Ice.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/841/Sea-Ice</dc:description>
+        <rdfs:label xml:lang="en">sea ice thickness</rdfs:label>
+        <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/ECSO_00002086"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000057 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000057">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000501"/>
+        <obo:IAO_0000115>The duration of time a particular area of sea ice has persisted in its solid state.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:12:34Z</dc:date>
+        <dc:description>This Target Variable is used to inform Vital Sign &apos;Sea Ice.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/841/Sea-Ice</dc:description>
+        <rdfs:label xml:lang="en">age of sea ice</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/ARCRC_00000057"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>The duration of time a particular area of sea ice has persisted in its solid state.</owl:annotatedTarget>
+        <dc:description>Age of sea ice is calculated using data from the National Snow &amp; Ice Data Center (NSIDC).</dc:description>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000058 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000058">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000040"/>
+        <obo:IAO_0000115>The loss of solid ice from a glacier into the ocean via calving.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:13:10Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Greenland Ice Sheet.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/842/Greenland-Ice-Sheet</dc:description>
+        <rdfs:label xml:lang="en">solid ice discharge</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/ARCRC_00000058"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>The loss of solid ice from a glacier into the ocean via calving.</owl:annotatedTarget>
+        <dc:description>The rate of solid ice discharge depends on the speed of glacier ice flow, the thickness of the ice, and the advance or retreat of the terminus of the glacier.</dc:description>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000059 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000059">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000503"/>
+        <obo:IAO_0000115>The fraction of solar radiation reflected by a surface.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:13:19Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign, &apos;Greenland Ice Sheet.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/842/Greenland-Ice-Sheet</dc:description>
+        <rdfs:label xml:lang="en">surface albedo</rdfs:label>
+        <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/ECSO_00001694"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000060 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000060">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000040"/>
+        <obo:IAO_0000115>Difference in Arctic land air temperature form the 1981-2010 mean (a positive anomaly is a higher temperature; a negative anomaly is a lower temperature).</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:13:32Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Surface Air Temperature.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/835/Surface-Air-Temperature</dc:description>
+        <rdfs:label xml:lang="en">Arctic land air temperature anomaly</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000061 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000061">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000040"/>
+        <obo:IAO_0000115>Difference in global temperature from the 1981-2010 mean (a positive anomaly is a higher temperature; a negative anomaly is a lower temperature).</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:13:49Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Surface Air Temperature.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/835/Surface-Air-Temperature</dc:description>
+        <rdfs:label xml:lang="en">global land air temperature anomaly</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000062 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000062">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000040"/>
+        <obo:IAO_0000115>Difference in seasonal or annual air temperatures from the 1981-2010 mean (a positive anomaly is a higher temperature; a negative anomaly is a lower temperature).</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:14:06Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Surface Air Temperature.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/835/Surface-Air-Temperature</dc:description>
+        <rdfs:label xml:lang="en">seasonal/annual anomaly patterns for air temperatures</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000063 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000063">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000503"/>
+        <obo:IAO_0000115>Quasi-liquid film that can occur on the surface of a solid even below melting point; the thickness of the film is temperature dependent.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:14:24Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Greenland Ice Sheet.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/842/Greenland-Ice-Sheet</dc:description>
+        <rdfs:label xml:lang="en">surface melt</rdfs:label>
+        <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/ECSO_00002845"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000064 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000064">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000040"/>
+        <obo:IAO_0000115>The net balance between mass gain vs. mass loss.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:14:38Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Greenland Ice Sheet.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/842/Greenland-Ice-Sheet</dc:description>
+        <rdfs:label xml:lang="en">total mass balance</rdfs:label>
+        <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/ECSO_00002886"/>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/ARCRC_00000064"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>The net balance between mass gain vs. mass loss.</owl:annotatedTarget>
+        <dc:description>Total mass balance is commonly applied for measuring land ice (glaciers and ice sheets). It is typically measured over one year, which includes one accumulation season plus one ablation season (often September - August for the Arctic)</dc:description>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000065 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000065">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000503"/>
+        <obo:IAO_0000115>Net balance between ice gained (via accumulation) vs. ice loss (via ablation) at the surface.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:14:51Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Greenland Ice Sheet.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/842/Greenland-Ice-Sheet</dc:description>
+        <rdfs:label xml:lang="en">surface mass balance</rdfs:label>
+        <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/ECSO_00002641"/>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/ARCRC_00000065"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Net balance between ice gained (via accumulation) vs. ice loss (via ablation) at the surface.</owl:annotatedTarget>
+        <dc:description>Surface mass balance is commonly applied for measuring land ice (glaciers and ice sheets).</dc:description>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000066 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000066">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000040"/>
+        <obo:IAO_0000115>Loss in ice mass due to melting, sublimation, evaporation, ice calving, aeolian processes like blowing snow, avalanche, and any other ablation.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:15:01Z</dc:date>
+        <dc:description>This Key Variable was used to inform the Vital Sign, &apos;Greenland Ice Sheet.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/842/Greenland-Ice-Sheet</dc:description>
+        <rdfs:label xml:lang="en">ice ablation</rdfs:label>
+        <rdfs:seeAlso>ice ablation zone: http://purl.obolibrary.org/obo/ENVO_01000914
+glacial ice ablation process:  http://purl.obolibrary.org/obo/ENVO_01000919</rdfs:seeAlso>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000067 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000067">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000040"/>
+        <obo:IAO_0000115>The annual change in total ice area of a marine-terminating glacier as a result of the advance or retreat of the terminal end of a glacier.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:15:16Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign, &apos;Greenland Ice Sheet.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/842/Greenland-Ice-Sheet</dc:description>
+        <rdfs:label xml:lang="en">marine terminating glacier front annual area change</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000068 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000068">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000040"/>
+        <obo:IAO_0000115>The large-scale movement of air, and together with ocean circulation, is the means by which thermal energy is redistributed on the surface of the earth.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-06T00:49:30Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Surface Air Temperature.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/835/Surface-Air-Temperature</dc:description>
+        <rdfs:label xml:lang="en">atmospheric wind circulation</rdfs:label>
+        <rdfs:seeAlso>https://glossary.ametsoc.org/wiki/Wind</rdfs:seeAlso>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000500 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000500">
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-06T04:35:46Z</dc:date>
+        <dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">Issued annually since 2006, the Arctic Report Card is a timely and peer-reviewed source for clear, reliable and concise environmental information on the current state of different components of the Arctic environmental system relative to historical records. The Report Card is intended for a wide audience, including scientists, teachers, students, decision-makers and the general public interested in the Arctic environment and science.
+
+The main website for the Arctic Report Card as of Nov 1, 2020 is: https://arctic.noaa.gov/Report-Card</dc:description>
+        <rdfs:label xml:lang="en">Arctic Report Card Component</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000501 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000501">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000040"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-06T04:47:36Z</dc:date>
+        <rdfs:label xml:lang="en">sea ice key variable</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000502 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000502">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000040"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-06T04:48:36Z</dc:date>
+        <rdfs:label xml:lang="en">snow key variable</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000503 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000503">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000040"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-06T04:51:42Z</dc:date>
+        <rdfs:label xml:lang="en">surface-based key variable</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000504 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000504">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000500"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-06T04:59:24Z</dc:date>
+        <rdfs:label xml:lang="en">Arctic Report Card 2020 Component</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000505 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000505">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000506"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000506 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000506">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000500"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-06T16:07:02Z</dc:date>
+        <rdfs:label xml:lang="en">Place</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000510 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000510">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000500"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-19T00:56:31Z</dc:date>
+        <dc:description>Essays are indicators of the state of the Arctic environmental system. They are assessed using measurements of and/or proxies for Key Variables. Essays are classified under one of three categories: Vital Signs, Other Indicators, and Frostbites.</dc:description>
+        <rdfs:label xml:lang="en">Arctic Report Card Essay</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000512 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000512">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000510"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-01T01:21:33Z</dc:date>
+        <rdfs:label xml:lang="en">Other Indicators</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000513 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000513">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000510"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-01T01:21:50Z</dc:date>
+        <rdfs:label xml:lang="en">Frostbites</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000514 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000514">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000042"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-01T01:25:18Z</dc:date>
+        <dc:description>MaxNDVI is the peak NDVI value for the year and is related to the annual maximum biomass of aboveground vegetation that is reached in midsummer (typically late July or early August).</dc:description>
+        <rdfs:label xml:lang="en">MaxNDVI</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000515 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ARCRC_00000515">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ARCRC_00000042"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-01T01:28:06Z</dc:date>
+        <dc:description>TI (time-integrated) NDVI is the sum of the biweekly NDVI values for the growing season and is correlated with the total aboveground vegetation productivity.</dc:description>
+        <rdfs:label xml:lang="en">TI-NDVI</rdfs:label>
+        <skos:altLabel>TI (time-integrated) NDVI</skos:altLabel>
+    </owl:Class>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000009 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.dataone.org/odo/ARCRC_00000009">
+        <owl:sameAs rdf:resource="http://purl.dataone.org/odo/ECSO_00001747"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000042 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.dataone.org/odo/ARCRC_00000042">
+        <owl:sameAs rdf:resource="http://www.purl.dataone.org/odo/ECSO_00010076"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000047 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.dataone.org/odo/ARCRC_00000047">
+        <owl:sameAs rdf:resource="http://purl.dataone.org/odo/ECSO_00001523"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000048 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.dataone.org/odo/ARCRC_00000048">
+        <owl:sameAs rdf:resource="http://purl.dataone.org/odo/ECSO_00000516"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000051 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.dataone.org/odo/ARCRC_00000051">
+        <owl:sameAs rdf:resource="http://purl.dataone.org/odo/ECSO_00001205"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000054 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.dataone.org/odo/ARCRC_00000054">
+        <owl:sameAs rdf:resource="http://purl.dataone.org/odo/ECSO_00002654"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000505 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.dataone.org/odo/ARCRC_00000505">
+        <owl:sameAs rdf:resource="https://schema.org/Place"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000507 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.dataone.org/odo/ARCRC_00000507">
+        <rdf:type rdf:resource="http://purl.dataone.org/odo/ARCRC_00000505"/>
+        <owl:sameAs rdf:resource="http://purl.obolibrary.org/obo/GAZ_00001507"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-06T16:08:24Z</dc:date>
+        <rdfs:label xml:lang="en">Greenland</rdfs:label>
+        <rdfs:seeAlso rdf:resource="http://purl.obolibrary.org/obo/GAZ_00001507"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000508 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.dataone.org/odo/ARCRC_00000508">
+        <rdf:type rdf:resource="http://purl.dataone.org/odo/ARCRC_00000505"/>
+        <owl:sameAs rdf:resource="http://purl.obolibrary.org/obo/GAZ_00011748"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-06T16:16:13Z</dc:date>
+        <rdfs:label xml:lang="en">Greenland Ice Sheet</rdfs:label>
+        <rdfs:seeAlso rdf:resource="http://purl.obolibrary.org/obo/GAZ_00011748"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000509 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.dataone.org/odo/ARCRC_00000509">
+        <rdf:type rdf:resource="http://purl.dataone.org/odo/ARCRC_00000505"/>
+        <owl:sameAs rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000323"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-07T01:31:38Z</dc:date>
+        <rdfs:label xml:lang="en">Arctic Ocean</rdfs:label>
+        <skos:altLabel>Arctic Sea</skos:altLabel>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ARCRC_00000518 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.dataone.org/odo/ARCRC_00000518">
+        <owl:sameAs rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ECSO_00000324 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.dataone.org/odo/ECSO_00000324">
+        <owl:sameAs rdf:resource="http://purl.obolibrary.org/obo/ENVO_04000013"/>
+        <oboInOwl:id>ECSO_00000324</oboInOwl:id>
+        <rdfs:label>Particulate Organic Carbon</rdfs:label>
+        <skos:altLabel>POC</skos:altLabel>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ECSO_00000516 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.dataone.org/odo/ECSO_00000516"/>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ECSO_00001205 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.dataone.org/odo/ECSO_00001205"/>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ECSO_00001523 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.dataone.org/odo/ECSO_00001523"/>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ECSO_00001747 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.dataone.org/odo/ECSO_00001747"/>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ECSO_00002654 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.dataone.org/odo/ECSO_00002654"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_04000013 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/ENVO_04000013"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GAZ_00000323 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GAZ_00000323"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GAZ_00001507 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GAZ_00001507"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GAZ_00011748 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GAZ_00011748"/>
+    
+
+
+    <!-- http://www.purl.dataone.org/odo/ECSO_00010076 -->
+
+    <owl:NamedIndividual rdf:about="http://www.purl.dataone.org/odo/ECSO_00010076"/>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#wasInfluencedBy -->
+
+    <owl:NamedIndividual rdf:about="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+    
+
+
+    <!-- https://schema.org/Place -->
+
+    <owl:NamedIndividual rdf:about="https://schema.org/Place"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotations
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <rdf:Description rdf:about="http://purl.dataone.org/odo/ARCRC_00000009">
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-02T18:39:21Z</dc:date>
+        <obo:IAO_0000115>The depth of water contained within a snowpack if the snowpack were melted instantly.</obo:IAO_0000115>
+        <rdfs:seeAlso>https://nsidc.org/cryosphere/glossary/</rdfs:seeAlso>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <rdfs:label xml:lang="en">snow water equivalent</rdfs:label>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Terrestrial Snow Cover.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/843/Terrestrial-Snow-Cover</dc:description>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.dataone.org/odo/ARCRC_00000042">
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <skos:altLabel>NDVI</skos:altLabel>
+        <rdfs:label xml:lang="en">Normalized Difference Vegetation Index</rdfs:label>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:06:29Z</dc:date>
+        <obo:IAO_0000115>A remotely sensed indicator of the quantity of aboveground vegetation in an area of land (pixel size). Calculated from distinct wavelengths of visible and near-infrared sunlight reflected by a vegetated land surface.  NDVI is calculated using the equation: the near-infrared reflectance minus the red reflectance, divided by near-infrared reflectance plus red reflectance.</obo:IAO_0000115>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Tundra Greenness.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/838/Tundra-Greenness</dc:description>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.dataone.org/odo/ARCRC_00000047">
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:08:29Z</dc:date>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Sea Surface Temperature.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/840/Sea-Surface-Temperature</dc:description>
+        <rdfs:label xml:lang="en">sea surface temperature</rdfs:label>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <skos:altLabel>SST
+temperature of sea surface
+ocean surface temperature
+temperature of the ocean surface</skos:altLabel>
+        <obo:IAO_0000115>A water temperature which inheres in water close to the surface of an ocean or sea. The exact meaning of surface varies according to the measurement method used, but it is between 1 millimetre (0.04 in) and 20 metres (70 ft) below the sea surface.</obo:IAO_0000115>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.dataone.org/odo/ARCRC_00000048">
+        <obo:IAO_0000115>Chlorophyll-a is a specific form of chlorophyll used in oxygenic photosynthesis.</obo:IAO_0000115>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Arctic Ocean Primary Productivity.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/839/Arctic-Ocean-Primary-Productivity-The-Response-of-Marine-Algae-to-Climate-Warming-and-Sea-Ice-Decline</dc:description>
+        <rdfs:label xml:lang="en">chlorophyll-a concentration</rdfs:label>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:10:23Z</dc:date>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.dataone.org/odo/ARCRC_00000051">
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <obo:IAO_0000115>Depth of snow, which is precipitation in the form of flakes of crystalline water ice that falls from clouds.</obo:IAO_0000115>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:10:59Z</dc:date>
+        <rdfs:label xml:lang="en">snow depth</rdfs:label>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Terrestrial Snow Cover.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/843/Terrestrial-Snow-Cover</dc:description>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.dataone.org/odo/ARCRC_00000054">
+        <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/ECSO_00002654"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+        <dc:description>This Key Variable is used to inform Vital Sign &apos;Sea Ice.&apos; See the 2019 Essay here: https://arctic.noaa.gov/Report-Card/Report-Card-2019/ArtMID/7916/ArticleID/841/Sea-Ice</dc:description>
+        <obo:IAO_0000115>Defines a region as &quot;ice-covered&apos; or &quot;not ice-covered&quot; based on a threshold percentage of sea ice concentration per data cell.</obo:IAO_0000115>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-05T23:11:42Z</dc:date>
+        <rdfs:label xml:lang="en">sea ice extent</rdfs:label>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/ARCRC_00000054"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Defines a region as &quot;ice-covered&apos; or &quot;not ice-covered&quot; based on a threshold percentage of sea ice concentration per data cell.</owl:annotatedTarget>
+        <dc:description>A threshold of 15% is used for the Arctic Report Card assessments and is the most commonly used threshold.</dc:description>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.dataone.org/odo/ARCRC_00000505">
+        <rdfs:label xml:lang="en">Geographic Named Place</rdfs:label>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-06T16:06:54Z</dc:date>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+        <dc:description>General class for containing places and locations referenced in the Arctic Report Card</dc:description>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.dataone.org/odo/ARCRC_00000518">
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+        <rdfs:label xml:lang="en">wasInfluencedBy</rdfs:label>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-01T17:55:14Z</dc:date>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00000327">
+        <skos:altLabel>DOC</skos:altLabel>
+        <rdfs:label>Dissolved Organic Carbon</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#List">
+        <rdfs:label>List</rdfs:label>
+    </rdf:Description>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
+

--- a/src/main/resources/ontologies/SALMON.owl
+++ b/src/main/resources/ontologies/SALMON.owl
@@ -1,0 +1,7168 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:j.0="http://usefulinc.com/ns/doap#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:ECSO="http://purl.dataone.org/odo/ECSO_"
+    xmlns:SALMON="http://purl.dataone.org/odo/SALMON_"
+    xmlns:j.1="http://purl.dataone.org/odo/"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:j.2="http://rs.tdwg.org/dwc/terms/"
+    xmlns:j.3="http://purl.obolibrary.org/obo/"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:j.4="http://www.geneontology.org/formats/oboInOwl#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:IAO="http://purl.obolibrary.org/obo/IAO_"
+    xmlns:orcid="http://orcid.org/"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#" > 
+  <rdf:Description rdf:nodeID="A0">
+    <dc:source>https://en.wikipedia.org/wiki/Latitude</dc:source>
+    <owl:annotatedTarget>In geography, latitude is a geographic coordinate that specifies the north–south position of a point on the Earth's surface. Latitude is an angle (defined below) which ranges from 0° at the Equator to 90° (North or South) at the poles. Lines of constant latitude, or parallels, run east–west as circles parallel to the equator. Latitude is used together with longitude to specify the precise location of features on the surface of the Earth. On its own, the term latitude should be taken to be the geodetic latitude as defined below. Briefly, geodetic latitude at a point is the angle formed by the vector perpendicular (or normal) to the ellipsoidal surface from that point, and the equatorial plane. Also defined are six auxiliary latitudes that are used in special applications.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/ECSO_00002130"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A1">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Pacific_Ocean, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q98, accessed 2021-06-15</j.4:hasDbXref>
+    <owl:annotatedTarget>An ocean that extends from the Arctic in the north to the Antarctic in the south, bounded by Asia and Australia on the west and the Americas on the east.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000583"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000546">
+    <skos:definition>A small, electronic, sound-emitting device which is attached externally to a fish and collects information on fish movement patterns and the physical environment.</skos:definition>
+    <rdfs:label xml:lang="en">External acoustic tag</rdfs:label>
+    <dc:description>This type of identification can remain on a fish for several years, is used for individual tagging, and is most suitable for fish that weigh at least 100g (given current technology). One or more sutures are typically used to attach the tag to the fish's skin using a needle. Data is transmitted wirelessly, usually through the use of radio waves (in fresh water and air), acoustic signals (in water; the receiver must also be in the water) or via satellite communication (in air; the tag sends data after it releases from the fish and floats up to the surface). Many types of telemetry devices also act as bio-loggers and store information locally on the device. Reading is done using the tag’s associated equipment, often through a computer connection.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:38:49Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000558"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000764">
+    <skos:definition>Total number of recruits of age class 7.9.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 7.9 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T19:35:42Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000754"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000219">
+    <skos:definition>Objective comparative measure of hot or cold of water in a stream.</skos:definition>
+    <skos:closeMatch rdf:resource="http://purl.dataone.org/odo/ECSO_00001528"/>
+    <rdfs:label xml:lang="en">Stream water temperature</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-14T22:18:53Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000411"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000631">
+    <skos:definition>A fish measurement method in which the length from the most anterior part of a fish to the tip of the median caudal fin rays (i.e. fork) is recorded. Two common procedures are:
+
+(a) Using a measuring board: A fish is placed on its side on a measuring board with its snout against the rigid headpiece. A measurement is taken from the most anterior part to the tip of the median caudal fin rays (i.e. fork).
+
+(b) Using a tape measure: A fish is placed on its side, either on top of a tape measure or the tape measure is placed just above the dorsal side of the fish to record the measurement from the most anterior part to the tip of the median caudal fin rays (i.e. fork). It is important to not allow the tape to curve along the contoured side of the fish that is facing up, which can introduce bias into the measurement due to girth.</skos:definition>
+    <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/SALMON_00000128"/>
+    <rdfs:label xml:lang="en">Fork length measurement method</rdfs:label>
+    <dc:description>The fork length measurement method is commonly used in fish species that have forked caudal fins -- where the dorsal and ventral rays are longer than median rays. Longer rays are often damaged or eroded by contact with rocks, debris, or hatchery walls.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-14T20:44:42Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000630"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000740">
+    <skos:definition>Total number of recruits of age class 5.6.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 5.6 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:56:07Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000669"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A2">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>The weight of a specimen's stomach, taken after the stomach has been dissected from the fish but before being emptied of its contents.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000685"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A3">
+    <j.4:hasDbXref>https://www.adfg.alaska.gov/FedAidPDFs/fds06-70.pdf, accessed 2021-07-16</j.4:hasDbXref>
+    <owl:annotatedTarget>A method which is used to approximate the total weight of a fish and which involves wrapping a cloth tape measure perpendicular to the longitudinal axis of the fish to measure its circumference at the thickest point.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000779"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000679">
+    <rdfs:label xml:lang="en">Subregion</rdfs:label>
+    <rdfs:comment>A subregion is a part of a larger region or continent and is usually based on location. Cardinal directions, such as south or sou commonly used to define a subregion.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-22T22:51:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000678"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000522">
+    <skos:definition>The left pectoral fin of the fish is removed.</skos:definition>
+    <rdfs:label xml:lang="en">Left pectoral fin clip</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-04T19:41:04Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000560"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000413">
+    <skos:exactMatch>http://purl.dataone.org/odo/ECSO_00001528</skos:exactMatch>
+    <skos:definition>The objective measure of hot or cold of water in a river.</skos:definition>
+    <rdfs:label xml:lang="en">River water temperature</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-22T16:35:07Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000219"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A4">
+    <j.4:hasDbXref rdf:resource="http://semanticscience.org/resource/SIO_001050"/>
+    <owl:annotatedTarget>A numeric or alphanumeric code which represents a particular sample. A sample is defined as a limited quantity of something (e.g. an individual or set of individuals from a population, or a portion of a substance) to be used for testing, analysis, inspection, investigation, demonstration, or trial use.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000528"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/date">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A5">
+    <dc:source>https://github.com/darwin-sw/dsw/wiki/ClassTaxon#equivalence-of-taxon-and-taxoncon-%20cept-in-the-tdwg-ontology-and-the-darwin-core-standard, accessed 2021-04-28</dc:source>
+    <owl:annotatedTarget>A reference which is made to a taxon name along with a publication which explains how the author intends for the name to be applied.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000494"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000569">
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000593"/>
+    <skos:altLabel>Salvelinus malma
+S. malma
+"Dolly Varden" @en</skos:altLabel>
+    <rdfs:label xml:lang="en">Dolly Varden trout</rdfs:label>
+    <rdfs:comment>ADF&amp;G says that dolly varden are actually char (http://www.adfg.alaska.gov/index.cfm%3Fadfg=dollyvarden.main), though Wikipedia suggests that they are trout (https://en.wikipedia.org/wiki/Dolly_Varden_trout).  Formally, members of Genus Salvelinus are considered "char", but Dolly Varden are often interchangeably called "trout"</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-11T17:26:36Z</dc:date>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000126"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000654">
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000587"/>
+    <j.1:SALMON_00000618 rdf:resource="http://purl.dataone.org/odo/SALMON_00000612"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-16T17:31:20Z</dc:date>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000653"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:comment>Some populations of the coastal cutthroat trout (O. c. clarkii) are semi-anadromous. (source: https://en.wikipedia.org/wiki/Cutthroat_trout)</rdfs:comment>
+    <j.2:vernacularName rdf:resource="http://purl.dataone.org/odo/SALMON_00000652"/>
+    <rdfs:label xml:lang="en">Oncorhynchus clarkii clarkii</rdfs:label>
+    <j.2:nameAccordingTo rdf:resource="http://purl.dataone.org/odo/SALMON_00000595"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A6">
+    <rdf:rest rdf:nodeID="A7"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000240"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000763">
+    <skos:definition>Total number of recruits of age class 7.8.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 7.8 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T19:35:36Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000754"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A8">
+    <dc:source>https://en.wikipedia.org/wiki/Coastal_cutthroat_trout, accessed 2021-06-18
+https://www.wikidata.org/wiki/Q5138345, accessed 2021-06-18</dc:source>
+    <owl:annotatedTarget>Oncorhynchus clarkii clarkii (i.e. coastal cutthroat trout) is a subspecies of Oncorhynchus mykiss and one fo the Pacific trout species. The coastal cutthroat trout occurs in four distinct forms. A semi-anadromous or sea-run form is the most well known. Freshwater forms occur in both large and small rivers and streams and lake environments. The native range of the coastal cutthroat trout extends south from the southern coastline of the Kenai Peninsula in Alaska to the Eel River in Northern California. Coastal cutthroat trout are resident in tributary streams and rivers of the Pacific basin and are rarely found more than 100 miles (160 km) from the ocean.
+
+Physical Description: Freshwater forms of the coastal cutthroat trout are generally dark green to greenish-blue on back, olive-green on upper flank, silvery on lower flank and belly. They display more numerous flank spots below lateral line, irregular spots on dorsal, adipose and caudal fins and the anal, pectoral and pelvic fin bases. The gill covers are pinkish. Sea-run forms while in salt water and shortly after returning to fresh water are silvery with a bluish back, yellowish lower flanks and fins, and display sparse spots. Cutthroats usually display distinctive red, pink, or orange linear marks along the undersides of their mandibles in the lower folds of the gill plates. These markings are responsible for the common name "cutthroat" given to the trout by outdoor writer Charles Hallock in an 1884 article in The American Angler., although the red slashes are not unique to the cutthroat trout and some coastal rainbow trout and redband trout also display throat slashes. The sea-run forms of coastal cutthroat average 2 to 5 lb (0.9 to 2.3 kg), while stream-resident forms attain much smaller sizes 0.4 to 3.2 oz (11 to 91 g).
+
+Range: The native range of the coastal cutthroat trout extends south from the southern coastline of the Kenai Peninsula in Alaska to the Eel River in Northern California. Coastal cutthroat trout are resident in tributary streams and rivers of the Pacific basin and are rarely found more than 100 miles (160 km) from the ocean. Semi-anadromous, stream resident, fluvial and lake resident forms exist. The great majority of coastal cutthroat trout habitat coincides with the belt of Pacific coast coniferous rainforest that extends from Alaska southward into Northern California.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000653"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000630">
+    <rdfs:label xml:lang="en">Fish length determination method</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-14T20:43:46Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000182"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A9">
+    <dc:source>http://orcid.org/0000-0002-5300-3075</dc:source>
+    <owl:annotatedTarget>The gathering live or deceased fishes by hand.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000154"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000218">
+    <skos:exactMatch>http://purl.dataone.org/odo/ECSO_00001225</skos:exactMatch>
+    <skos:exactMatch rdf:resource="http://purl.obolibrary.org/obo/ENVO_09200001"/>
+    <skos:definition>Objective comparative measure of hot or cold of air.</skos:definition>
+    <rdfs:label xml:lang="en">Air temperature</rdfs:label>
+    <rdfs:comment>An Essential Salmon Variable (ESV) from the working list being developed by Graeme Diack et al. at the Atlantic Salmon Trust.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-14T22:18:45Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000217"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A10">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>This identification type will often last the entire life of the fish, is primarily used for group marking, and is most suitable for fish at least 2.5cm in length. The fish must be euthanized for reading. The tags are delivered on a spool, and the tagging machine magnetises, cuts and inserts the tag into the fish. While a detector can be used to determine if a fish is marked or not, a fish must be euthanized in order to remove the tag and read the engraved code.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000532"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002051">
+    <rdfs:label xml:lang="en">date</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-14T23:28:39Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002043"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000412">
+    <skos:exactMatch>http://purl.dataone.org/odo/ECSO_00001226</skos:exactMatch>
+    <skos:definition>An objective measure of hot or cold of water in a marine (i.e. ocean or sea) environment.</skos:definition>
+    <rdfs:label xml:lang="en">Seawater temperature</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-22T04:05:29Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000236"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000545">
+    <skos:definition>A tag which transmits information about a fish via an electronic receiver.</skos:definition>
+    <skos:altLabel>Biologger
+Biotelemetry tag
+Radio tag</skos:altLabel>
+    <rdfs:label xml:lang="en">Electronic tag</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:37:48Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000530"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000678">
+    <skos:definition>A spatial region whose boundaries are typically defined against some material frame of reference (like the earth).</skos:definition>
+    <rdfs:label xml:lang="en">Region</rdfs:label>
+    <dc:description>In geography, regions are areas that are broadly divided by physical characteristics (physical geography), human impact characteristics (human geography), and the interaction of humanity and the environment (environmental geography). Geographic regions and sub-regions are mostly described by their imprecisely defined, and sometimes transitory boundaries, except in human geography, where jurisdiction areas such as national borders are defined in law.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-22T22:51:02Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000675"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002054">
+    <rdfs:label xml:lang="en">seconds elapsed</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-15T01:05:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002068"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A11">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Coded_wire_tag, accessed 2021-05-05  https://www.wikidata.org/wiki/Q23581650, accessed 2021-05-05</j.4:hasDbXref>
+    <dc:source>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</dc:source>
+    <owl:annotatedTarget>A small metal pin which is inserted into the fish, usually into the cartilage of the snout.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000532"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000217">
+    <skos:definition>The degree of hotness or coldness of a body or environment (corresponding to its molecular activity).</skos:definition>
+    <skos:altLabel>temp
+temperature</skos:altLabel>
+    <owl:equivalentClass>http://purl.dataone.org/odo/ECSO_00001104</owl:equivalentClass>
+    <rdfs:label xml:lang="en">Temperature measurement type</rdfs:label>
+    <dc:description>Temperature is measured with thermometers that may be calibrated to a variety of temperature scales. Most scientists measure temperature using the Celsius scale and thermodynamic temperature using the Kelvin scale, which is the Celsius scale offset so that its null point is 0K = −273.15°C, or absolute zero. The basic unit of temperature in the International System of Units (SI) is the kelvin. It has the symbol K.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-14T22:18:17Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000214"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000568">
+    <skos:definition>The proportion of males and females in a smolt population.</skos:definition>
+    <rdfs:label xml:lang="en">Sex ratio of smolts</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-11T00:02:35Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000563"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000677">
+    <rdfs:label xml:lang="en">Place</rdfs:label>
+    <dc:description>In geography, location or place are used to denote a region (point, line, or area) on Earth’s surface or elsewhere. The term location generally implies a higher degree of certainty than place, the latter often indicating an entity with an ambiguous boundary, relying more on human or social attributes of place identity and sense of place than on geometry.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-22T22:51:00Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000675"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A12">
+    <dc:source>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</dc:source>
+    <owl:annotatedTarget>The adipose fin is removed using scissors or a razor blade.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000535"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000653">
+    <dc:description>Oncorhynchus clarkii clarkii (i.e. coastal cutthroat trout) is a subspecies of Oncorhynchus mykiss and one fo the Pacific trout species. The coastal cutthroat trout occurs in four distinct forms. A semi-anadromous or sea-run form is the most well known. Freshwater forms occur in both large and small rivers and streams and lake environments. The native range of the coastal cutthroat trout extends south from the southern coastline of the Kenai Peninsula in Alaska to the Eel River in Northern California. Coastal cutthroat trout are resident in tributary streams and rivers of the Pacific basin and are rarely found more than 100 miles (160 km) from the ocean.
+
+Physical Description: Freshwater forms of the coastal cutthroat trout are generally dark green to greenish-blue on back, olive-green on upper flank, silvery on lower flank and belly. They display more numerous flank spots below lateral line, irregular spots on dorsal, adipose and caudal fins and the anal, pectoral and pelvic fin bases. The gill covers are pinkish. Sea-run forms while in salt water and shortly after returning to fresh water are silvery with a bluish back, yellowish lower flanks and fins, and display sparse spots. Cutthroats usually display distinctive red, pink, or orange linear marks along the undersides of their mandibles in the lower folds of the gill plates. These markings are responsible for the common name "cutthroat" given to the trout by outdoor writer Charles Hallock in an 1884 article in The American Angler., although the red slashes are not unique to the cutthroat trout and some coastal rainbow trout and redband trout also display throat slashes. The sea-run forms of coastal cutthroat average 2 to 5 lb (0.9 to 2.3 kg), while stream-resident forms attain much smaller sizes 0.4 to 3.2 oz (11 to 91 g).
+
+Range: The native range of the coastal cutthroat trout extends south from the southern coastline of the Kenai Peninsula in Alaska to the Eel River in Northern California. Coastal cutthroat trout are resident in tributary streams and rivers of the Pacific basin and are rarely found more than 100 miles (160 km) from the ocean. Semi-anadromous, stream resident, fluvial and lake resident forms exist. The great majority of coastal cutthroat trout habitat coincides with the belt of Pacific coast coniferous rainforest that extends from Alaska southward into Northern California.</dc:description>
+    <skos:definition>The class which contains all instances of Oncorhynchus clarkii clarkii.</skos:definition>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-16T16:26:35Z</dc:date>
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000651"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000594"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <skos:altLabel>O. c. clarkii
+Onchorhynchus c. clarkii
+sea-run cutthroat trout
+blueback trout
+harvest trout</skos:altLabel>
+    <rdfs:label xml:lang="en">Oncorhynchus clarkii clarkii</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.4:hasDbXref>NCBI:txid69121</j.4:hasDbXref>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000762">
+    <skos:definition>Total number of recruits of age class 7.7.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 7.7 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T19:35:30Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000754"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A13">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>The left pectoral fin of the fish is removed.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000522"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#broadMatch">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000520">
+    <skos:definition>The parental year for a group of returning salmon, i.e. the calendar year when the majority of parents of these fish spawned.</skos:definition>
+    <rdfs:label xml:lang="en">Brood year</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-04T17:25:52Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002050"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000411">
+    <skos:exactMatch>http://purl.dataone.org/odo/ECSO_00001525</skos:exactMatch>
+    <skos:definition>The objective measure of hot or cold in freshwater (i.e. non-saline water).</skos:definition>
+    <rdfs:label xml:lang="en">Freshwater temperature</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-22T04:05:19Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000236"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A14">
+    <j.4:hasDbXref>http://purl.dataone.org/odo/ECSO_00001237</j.4:hasDbXref>
+    <owl:annotatedTarget>Measurement types which pertain to any product of the condensation of atmospheric water vapor that falls under gravity.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000220"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000544">
+    <skos:definition>This identification type will last the lifetime of the fish, is used for group marking, and is most suitable for salmonids that are at least 7cm in length.</skos:definition>
+    <skos:definition>One of the pelvic fins is removed using scissors.</skos:definition>
+    <rdfs:label xml:lang="en">Pelvic fin clip</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:36:17Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000540"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002053">
+    <rdfs:label xml:lang="en">part of season measurement made</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-15T00:16:39Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00001167"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A15">
+    <dc:source>http://purl.obolibrary.org/obo/ENVO_00000029</dc:source>
+    <owl:annotatedTarget>A flowing body of water.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000230"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A16">
+    <dc:source>https://en.wikipedia.org/wiki/10th_edition_of_Systema_Naturae, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q4547210, accessed 2021-06-15</dc:source>
+    <owl:annotatedTarget>The 10th edition of Systema Naturae is a book written by Swedish naturalist Carl Linnaeus and published in two volumes in 1758 and 1759, which marks the starting point of zoological nomenclature. In it, Linnaeus introduced binomial nomenclature for animals, something he had already done for plants in his 1753 publication of Species Plantarum.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000588"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A17">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>A numeric value assigned to a scale gum card.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000680"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A18">
+    <owl:someValuesFrom rdf:resource="http://purl.dataone.org/odo/SALMON_00000495"/>
+    <owl:onProperty rdf:resource="http://rs.tdwg.org/dwc/terms/nameAccordingTo"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00001183">
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00001167"/>
+    <skos:prefLabel>Time Step</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <skos:altLabel>time interval</skos:altLabel>
+    <rdfs:label>Time Step</rdfs:label>
+    <skos:hiddenLabel>Time Step</skos:hiddenLabel>
+    <skos:altLabel>duration</skos:altLabel>
+    <j.3:IAO_0000115>Interval of time representing duration of observation</j.3:IAO_0000115>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5896-7295"/>
+    <j.4:hasExactSynonym>time interval</j.4:hasExactSynonym>
+    <j.4:hasExactSynonym>duration</j.4:hasExactSynonym>
+    <j.3:IAO_0000119>Adapted from
+http://en.wikipedia.org/wiki/Time</j.3:IAO_0000119>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000458">
+    <skos:definition>In biological taxonomy, Type generically refers to the official name applied to a taxon. This Class constrains Type members as belonging to family Salmonidae</skos:definition>
+    <skos:altLabel>Scientific name
+Binomial name
+Binomen
+Latin name</skos:altLabel>
+    <rdfs:label xml:lang="en">Salmonid Type</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-26T20:17:29Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000215"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000216">
+    <skos:definition>A categorical measurement type which describes the sex of a fish or group of fish(es), where sex is defined as the assemblage of physical properties or qualities of a fish by which male is distinguished from female; the physical difference between male and female; the distinguishing peculiarity of male or female.</skos:definition>
+    <skos:closeMatch>http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C28421</skos:closeMatch>
+    <rdfs:label xml:lang="en">Fish sex measurement type</rdfs:label>
+    <rdfs:comment>May be better to map to PATO, that has some potentially better definitions-- e.g.
+biological sex: http://purl.obolibrary.org/obo/PATO_0000047
+phenotypic sex: http://purl.obolibrary.org/obo/PATO_0001894</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-14T19:59:20Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000167"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000676">
+    <skos:definition>A reference to a position on the Earth, by its name or by its geographical location.</skos:definition>
+    <rdfs:label xml:lang="en">Location</rdfs:label>
+    <rdfs:comment>[NEEDS ALIGNMENT]
+
+http://purl.obolibrary.org/obo/GAZ_00000448</rdfs:comment>
+    <rdfs:comment>In geography, location or place are used to denote a region (point, line, or area) on Earth’s surface or elsewhere. The term location generally implies a higher degree of certainty than place, the latter often indicating an entity with an ambiguous boundary, relying more on human or social attributes of place identity and sense of place than on geometry.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-22T22:50:56Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000675"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000785">
+    <rdfs:label xml:lang="en">Sport fishery harvest count</rdfs:label>
+    <rdfs:comment>Estimates of number of fish caught based on some sport harvest</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2022-06-10T21:46:57Z</dc:date>
+    <dc:creator rdf:resource="https://orcid.org/0000-0002-0381-3766"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000491"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000652">
+    <skos:broadMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000603"/>
+    <rdfs:label xml:lang="en">Coastal cutthroat trout</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-16T16:10:16Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.2:scientificName rdf:resource="http://purl.dataone.org/odo/SALMON_00000654"/>
+    <owl:sameAs rdf:resource="http://purl.dataone.org/odo/SALMON_00000654"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000653"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000126"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A19">
+    <dc:source>Schiewe, MH (2013) Salmon. Encyclopedia of Biodiversity (Second Edition). pg. 522-531. https://doi.org/10.1016/B978-0-12-384719-5.00293-8</dc:source>
+    <owl:annotatedTarget>﻿A classification of fishes which spawn in freshwater, migrate to the ocean to forage and mature, and return to freshwater to spawn and begin the cycle again.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000615"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000761">
+    <skos:definition>Total number of recruits of age class 7.6.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 7.6 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T19:35:23Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000754"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A20">
+    <j.4:hasDbXref>https://www.monitoringresources.org/Document/Method/Details/1549, accessed 2021-03-31</j.4:hasDbXref>
+    <owl:annotatedTarget>A fish length measurement taken from the mid-orbit (i.e. eye) to the posterior insertion of the anal fin.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000132"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A21">
+    <rdfs:comment>Indigenous names for salmon can be found by exploring each SASAP region's page on the State of Alaska's Salmon and People website (for example, see the Arctic Region here: https://alaskasalmonandpeople.org/region/arctic/)</rdfs:comment>
+    <dc:source>https://alaskasalmonandpeople.org/regions/, accessed 2021-04-16</dc:source>
+    <owl:annotatedTarget>"Iqalugruaq" @ipk
+"Aqalugruaq" @ipk
+"Noolaaghe" [Denaakk'e, Koyukon Athabaskan]
+"Nahdlii" @gwi
+"Shii" @gwi
+"Aluyak" @ypk
+"Iqalluk" @ypk
+"Kangitneq" @ypk
+"Mac'utaq" @ypk
+"Teggmaarrluk" @ypk [Unangam tunuu variant]
+"x̂aykix̂" @ale
+"Alimaq" [Alutiiq/Sugpiaq]
+"alima" [Kenai Dena'ina]
+"tiitl'" @eya
+"Gaynii"@tsi @tli
+"téel'" @tsi @tli</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000240"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A22">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <owl:intersectionOf rdf:nodeID="A23"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A24">
+    <dc:source>https://en.wikipedia.org/wiki/Steelhead_trout, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q64437771, accessed 2021-06-15</dc:source>
+    <owl:annotatedTarget>Oncorhynchus mykiss irideus
+Oncorhynchus m. irideus
+O. m. irideus
+"steelhead" @en</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000570"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000543">
+    <skos:definition>The flap in the corner of the mouth is clipped away (the maxilla - sometimes also the supermaxilla).</skos:definition>
+    <rdfs:label xml:lang="en">Maxilla clip</rdfs:label>
+    <dc:description>This identification type will last the entire lifetime of the fish, is used for group marking, and is most suitable for salmonids that are at least 10cm in length.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:35:46Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000540"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000567">
+    <skos:definition>The ratio of males and females in a juvenile standing stock.</skos:definition>
+    <rdfs:label xml:lang="en">Sex ratio of juvenile standing stock</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-11T00:01:49Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000563"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002250">
+    <rdfs:label xml:lang="en">longitude second component</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-28T21:59:23Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002132"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A25">
+    <j.4:hasDbXref>http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C25150</j.4:hasDbXref>
+    <owl:annotatedTarget>The duration of time for which a fish has been alive.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000184"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000699">
+    <skos:definition>Total number of recruits of age class 1.4.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 1.4 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:47:12Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000665"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000239">
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000464"/>
+    <skos:altLabel>Oncorhynchus tshawytscha
+O. tshawytscha
+"king salmon" @en
+"Quinnat salmon" @en
+"spring salmon" @en
+"chrome hog" @en
+"Blackmouth" @en
+"Tyee salmon" @en</skos:altLabel>
+    <skos:altLabel>"Sikayujak" @ipk
+"Ggaal" [Denaakk'e, Koyukon Athabaskan]
+"Gath" [Benhti Kenaga, Lower Tanana]
+"Luk Choo" @gwi
+"Kiagtaq" @ypk
+"Taryaqvak" @ypk
+"Aciirturtet" @ypk
+"sumgax̂" @ale [Unangam tunuu variant]
+"chaguchax̂" @ale [Unangam tunuu variant]
+"chavichax̂" @ale [Unangam tunuu variant]
+"Aamasuuk" [Alutiiq/Sugpiaq]
+"Liliksak" [Alutiiq/Sugpiaq]
+"Luk'ece'e"  [Ahtna]
+"Kentsinai'i" [Ahtna]
+"luq'aka'a" [Kenai Dena'ina]
+"nudlaghi" [Kenai Dena'ina]
+"te'ya'lee" @eya
+"Yee" @tsi @tli
+"t'á" @tsi @tli</skos:altLabel>
+    <rdfs:label xml:lang="en">Chinook salmon</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-16T18:10:30Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000675">
+    <rdfs:label xml:lang="en">Geospatial information</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-22T22:50:49Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000651">
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000653"/>
+    <skos:altLabel>Oncorhynchus clarkii clarkii
+Oncorhynchus c. clarkii
+O. c. clarkii</skos:altLabel>
+    <rdfs:label xml:lang="en">Coastal cutthroat trout</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-16T16:09:57Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000582"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000760">
+    <skos:definition>Total number of recruits of age class 7.5.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 7.5 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T19:35:15Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000754"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A26">
+    <dc:source>https://www.fishbase.se/Glossary/Glossary.php?q=stock&amp;language=english&amp;sc=is, accessed 2021-06-15</dc:source>
+    <owl:annotatedTarget>Group of individuals of a species which can be regarded as an entity for management or assessment purposes; a separate breeding population of a species; term used to identify a management unit of fishery species. A distinct genetic population, a population defined by movement pattern, part of a population potentially harvestable, or a quantity of fish from a given area. May be a total or a spawning stock.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000639"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A27">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Spearfishing, accessed 2021-04-01
+https://www.wikidata.org/wiki/Q765706, accessed 2021-04-01</j.4:hasDbXref>
+    <owl:annotatedTarget>A barbed pole, which is used to strike and collect a fish. Spearheads come in a variety of different shapes (e.g. arrow, trident), and can be thrown by hand or deployed using elastic-powered spearguns and slings or compressed gas pneumatic powered spearguns.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000146"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000542">
+    <skos:definition>A portion of the upper caudal fin lobe is removed.</skos:definition>
+    <rdfs:label xml:lang="en">Upper caudal fin clip</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:31:23Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000540"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000566">
+    <skos:definition>The proportion of males and females in an adult spawning stock.</skos:definition>
+    <rdfs:label xml:lang="en">Sex ratio of adult spawning stock</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-11T00:01:35Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000563"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000215">
+    <rdfs:label xml:lang="en">Salmonid species name or identifier</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-14T18:47:11Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000829"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A28">
+    <dc:source>https://www.solitudelakemanagement.com/blog/know-your-pond-life-fin-clipping-for-fisheries-management-success/, accessed 2021-05-05</dc:source>
+    <owl:annotatedTarget>A portion of the lower caudal fin lobe is removed.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000541"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A29">
+    <dc:source>https://en.wikipedia.org/wiki/Sex_ratio, accessed 10May2021
+https://www.wikidata.org/wiki/Q1068155, accessed 10May2021</dc:source>
+    <owl:annotatedTarget>The ratio of males to females in a population.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000563"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A30">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Radio-frequency_identification, accessed 2021-05-05
+https://www.wikidata.org/wiki/Q104954, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>A system which uses electromagnetic fields to automatically identify and track tags attached to objects.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000550"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A31">
+    <rdf:rest rdf:nodeID="A32"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000569"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A33">
+    <owl:someValuesFrom rdf:resource="http://purl.dataone.org/odo/SALMON_00000884"/>
+    <owl:onProperty rdf:resource="http://rs.tdwg.org/dwc/terms/scientificName"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000238">
+    <skos:definition>A biological sex quality inhering in an individual or a population that only produces gametes that can be fertilised by male gametes.</skos:definition>
+    <owl:equivalentClass>http://purl.obolibrary.org/obo/PATO_0000383</owl:equivalentClass>
+    <rdfs:label xml:lang="en">Female</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-15T20:51:08Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000216"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A34">
+    <rdf:rest rdf:nodeID="A35"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000591"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000698">
+    <skos:definition>Total number of recruits of age class 1.3.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 1.3 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:46:55Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000665"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000129">
+    <skos:definition>A fish length measurement taken from the hind margin of the orbit to the tip of the median caudal fin rays.</skos:definition>
+    <skos:altLabel>POFK</skos:altLabel>
+    <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/SALMON_00000635"/>
+    <rdfs:label xml:lang="en">Post-orbit to fork of tail length</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T18:19:40Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000127"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000674">
+    <rdfs:label xml:lang="en">Fish stock name</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-21T20:16:55Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000783">
+    <rdfs:label xml:lang="en">Subsistence fishery harvest count</rdfs:label>
+    <rdfs:comment>Estimates of number of fish caught based on some subsistence harvest</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2022-06-10T21:46:57Z</dc:date>
+    <dc:creator rdf:resource="https://orcid.org/0000-0002-0381-3766"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000491"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000650">
+    <rdfs:label xml:lang="en">Semi-anadromous</rdfs:label>
+    <rdfs:comment>Term to designate that some, but not all, individuals of the taxon migrate from freshwater into the ocean for part of their life history.  Used as Existential Quantifier on the appropriate taxonomic Class to indicate anadromous behavior of some Instances of that Class.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-16T16:03:41Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000614"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A36">
+    <dc:source>https://en.wikipedia.org/wiki/Sea_louse, accessed 2021-06-23
+https://www.wikidata.org/wiki/Q3808922, accessed 2021-06-23</dc:source>
+    <owl:annotatedTarget>A sea louse (plural sea lice, not to be confused with sea fleas), is a member of the Caligidae family of copepods (small crustaceans) within the order Siphonostomatoida. The roughly 559 species in 37 genera include around 162 Lepeophtheirus and 268 Caligus species. Sea lice are marine ectoparasites (external parasites) that feed on the mucus, epidermal tissue, and blood of host marine fish.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000688"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000541">
+    <skos:definition>A portion of the lower caudal fin lobe is removed.</skos:definition>
+    <rdfs:label xml:lang="en">Lower caudal fin clip</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:30:45Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000540"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/ssn/isProxyFor">
+    <rdfs:range rdf:resource="http://purl.dataone.org/odo/SALMON_00000184"/>
+    <rdfs:domain rdf:resource="http://purl.dataone.org/odo/SALMON_00000484"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000214">
+    <skos:definition>A measurement type taken of some non-living chemical or physical component of the environment.</skos:definition>
+    <rdfs:label xml:lang="en">Environmental measurement type</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-14T18:23:43Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#MeasurementType"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000589">
+    <rdfs:label xml:lang="en">Salmo spp.</rdfs:label>
+    <j.4:hasDbXref>NCBI:txid8028</j.4:hasDbXref>
+    <dc:description>Salmo is a genus of fish in the salmon family Salmonidae that includes the European species of salmon and trout, among them the familiar Atlantic salmon Salmo salar and the brown trout Salmo trutta.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-27T00:02:38Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000586"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002058">
+    <skos:altLabel>Julian day</skos:altLabel>
+    <rdfs:label xml:lang="en">day of year</rdfs:label>
+    <j.4:hasExactSynonym>Julian day</j.4:hasExactSynonym>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-15T18:26:54Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002043"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A37">
+    <dc:source rdf:resource="http://purl.obolibrary.org/obo/PCO_0000076"/>
+    <owl:annotatedTarget>A community species diversity that is the total species diversity in a landscape. The area or landscape of interest may be of very different sizes in different situations, but it should encompass multiple sites or habitats as measured by alpha diversity.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000627"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A38">
+    <j.4:hasDbXref>https://www.adfg.alaska.gov/index.cfm?adfg=fishingHatcheries.main, accessed 2021-04-02</j.4:hasDbXref>
+    <dc:source>https://www.adfg.alaska.gov/static/fishing/PDFs/hatcheries/2013_ak_hatcheries.pdf, accessed 2021-04-02</dc:source>
+    <owl:annotatedTarget>The Alaska hatchery program was designed to increase salmon abundance and enhace fisheries, while protecting wild stocks. The program was built in response to depressed commercial fisheries, to meet the needs of the people of the state.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000173"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#hiddenLabel">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A39">
+    <dc:source rdf:resource="https://www.adfg.alaska.gov/sf/SARR/AWC/index.cfm?ADFG=intro.catalog"/>
+    <owl:annotatedTarget>Anadromous Waters Catalog water body code
+State of Alaska's Anadromous Waters Stream Catalog</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000780"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A40">
+    <dc:source>https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html, accessed 2021-05-04</dc:source>
+    <owl:annotatedTarget>The parental year for a group of returning salmon, i.e. the calendar year when the majority of parents of these fish spawned.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000520"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.geneontology.org/formats/oboInOwl#hasDbXref">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A41">
+    <dc:source>https://www.monitoringresources.org/Document/Method/Details/4041, accessed 2021-03-31</dc:source>
+    <owl:annotatedTarget>A fish length measurement taken from the most anterior part of a fish to the tip of the median caudal fin rays (i.e. fork).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000128"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A42">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Angling, accessed 2021-04-01</j.4:hasDbXref>
+    <owl:annotatedTarget>Fishing by means of an "angle" (fish hook). The hook is usually attached to a fishing line and baited with natural bait or artificial lures to attract fish. The line is often attached to a fishing rod.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000144"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000697">
+    <skos:definition>Total number of recruits of age class 1.2.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 1.2 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:46:25Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000665"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000128">
+    <skos:definition>A fish length measurement taken from the most anterior part of a fish to the tip of the median caudal fin rays (i.e. fork).</skos:definition>
+    <skos:altLabel>FL
+tip of snout to fork of tail</skos:altLabel>
+    <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/SALMON_00000631"/>
+    <rdfs:label xml:lang="en">Fork length</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T18:19:34Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000127"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000782">
+    <rdfs:label xml:lang="en">Recruits per spawner</rdfs:label>
+    <rdfs:comment>A count or other estimate of the number of fish returning to a breeding site from a spawning individual.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-20T21:55:30Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000781"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A43">
+    <owl:someValuesFrom rdf:resource="http://purl.dataone.org/odo/SALMON_00000495"/>
+    <owl:onProperty rdf:resource="http://rs.tdwg.org/dwc/terms/nameAccordingTo"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A44">
+    <j.4:hasDbXref>http://rs.tdwg.org/dwc/terms/lifeStage</j.4:hasDbXref>
+    <owl:annotatedTarget>The age class or life stage of the biological individual(s) at the time the occurrence was recorded.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000401"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000540">
+    <skos:definition>The removal of a portion or entirety of a fin or the maxilla of a fish, for identification purposes.</skos:definition>
+    <rdfs:label xml:lang="en">Fin or maxilla clip</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:29:24Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000557"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A45">
+    <rdf:rest rdf:nodeID="A46"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000242"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000237">
+    <skos:definition>A biological sex quality inhering in an individual or a population whose sex organs contain only male gametes.</skos:definition>
+    <owl:equivalentClass>http://purl.obolibrary.org/obo/PATO_0000384</owl:equivalentClass>
+    <rdfs:label xml:lang="en">Male</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-15T20:51:04Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:disjointWith rdf:resource="http://purl.dataone.org/odo/SALMON_00000238"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000216"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000588">
+    <rdfs:label xml:lang="en">Linnaeus, 1758</rdfs:label>
+    <dc:description>The 10th edition of Systema Naturae is a book written by Swedish naturalist Carl Linnaeus and published in two volumes in 1758 and 1759, which marks the starting point of zoological nomenclature. In it, Linnaeus introduced binomial nomenclature for animals, something he had already done for plants in his 1753 publication of Species Plantarum.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-26T23:58:33Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000495"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000479">
+    <skos:definition>The number of salmon which do not get caught by commercial or recreational fisheries and return to their freshwater spawning habitat.</skos:definition>
+    <rdfs:label xml:lang="en">Salmon escapement count</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-26T23:21:35Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000504"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A47">
+    <dc:source>https://www.fishbase.in/Glossary/Glossary.php?q=smolt&amp;language=english&amp;sc=is, accessed 2021-04-21</dc:source>
+    <owl:annotatedTarget>1) A young salmonid which has developed silvery coloring on its sides, obscuring the parr marks, and which is about to migrate or has just migrated into the sea, 2) to undergo the transformation from parr to smolt.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000404"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000696">
+    <skos:definition>Total number of recruits of age class 1.1.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 1.1 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:46:02Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000665"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2006/time#hasEnd">
+    <skos:definition>End of a temporal entity.</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A48">
+    <dc:source rdf:resource="https://en.wikipedia.org/wiki/Proxy_(statistics)"/>
+    <owl:annotatedTarget>A variable that is not in itself directly measured but inferred, and that serves in place of an unobservable or immeasurable variable. In order for a variable to be a good proxy, it must have a close correlation, not necessarily linear, with the variable of interest. This correlation might be either positive or negative.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000484"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000672">
+    <skos:definition>A name that identifies (that is, labels the identity of) either a unique object or a unique class of objects, where the "object" of class may be an idea, physical countable object (of class thereof), or physical noncountable substance (or class thereof). The abbreviation ID often refers to identity, identification (the process of identifying), or an identifier (that is, an instance of identification). An identifier may be a word, number, letter, symbol, or any combination of those.</skos:definition>
+    <rdfs:seeAlso>ID
+Identity</rdfs:seeAlso>
+    <rdfs:label xml:lang="en">Identifiers and Codes</rdfs:label>
+    <rdfs:comment>Identifiers and Codes are differentiated here from their potentially more commonly identifying "labels" that would called "Names", which are typically expressed more in natural language.
+
+In some cases, the distinction between a Station "Identifier/Code" and the "Station Name" may be ambiguous, or the same label might apply to both.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-21T20:12:18Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000781">
+    <rdfs:label xml:lang="en">Recruit abundance</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-20T21:55:15Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000504"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A49">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Notation, accessed 2021-06-14
+https://www.wikidata.org/wiki/Q2001982, accessed 2021-06-14</j.4:hasDbXref>
+    <dc:source rdf:resource="http://semanticscience.org/resource/SIO_001385"/>
+    <owl:annotatedTarget>A series or system of written symbols used to represent numbers, amounts, or elements.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000478"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000563">
+    <skos:definition>The ratio of males to females in a population.</skos:definition>
+    <rdfs:label xml:lang="en">Sex ratio</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-10T22:51:40Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000476"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000127">
+    <skos:definition>A numerical value which represents the length of a fish, typically in units of millimeters, centimeters, or inches.</skos:definition>
+    <skos:closeMatch>http://purl.dataone.org/odo/ECSO_00000553</skos:closeMatch>
+    <rdfs:label xml:lang="en">Fish length measurement type</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T17:43:39Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000167"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000587">
+    <rdfs:label xml:lang="en">Oncorhynchus spp.</rdfs:label>
+    <j.4:hasDbXref>NCBI:txid8016</j.4:hasDbXref>
+    <dc:description>Oncorhynchus is a genus of fish in the family Salmonidae; it contains the Pacific salmon and Pacific trout. The name of the genus is derived from the Greek ὄγκος (ónkos, “lump, bend”) + ῥύγχος (rhúnkhos, “snout”), in reference to the hooked jaws of males in the mating season (the "kype").</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-26T23:57:17Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000478">
+    <skos:definition>A series or system of written symbols used to represent numbers, amounts, or elements.</skos:definition>
+    <rdfs:label xml:lang="en">Notation type</rdfs:label>
+    <rdfs:comment>[NEEDS ALIGNMENT]
+
+http://semanticscience.org/resource/SIO_001385</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-26T23:10:08Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000236">
+    <skos:definition>Objective comparative measure of hot or cold of water temperature in an aquatic environment.</skos:definition>
+    <skos:closeMatch rdf:resource="http://purl.obolibrary.org/obo/ENVO_09200014"/>
+    <rdfs:label xml:lang="en">Aquatic temperature</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-15T20:49:21Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000217"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A50">
+    <dc:source>https://en.wikipedia.org/wiki/Salvelinus, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q548682, accessed 2021-06-15</dc:source>
+    <owl:annotatedTarget>Salvelinus is a genus of salmonid fish often called char or charr; some species are called "trout". Salvelinus is a member of the subfamily Salmoninae within the family Salmonidae.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000592"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A51">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Body_of_water, accessed 2021-03-30
+https://www.wikidata.org/wiki/Q15324, accessed 2021-03-30</j.4:hasDbXref>
+    <owl:annotatedTarget>An accumulation of water of varying size.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000125"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A52">
+    <j.4:hasDbXref>https://alaskasalmonandpeople.org/working-group/governance-and-subsistence/, accessed 2021-04-02</j.4:hasDbXref>
+    <j.4:hasDbXref>http://www.adfg.alaska.gov/index.cfm?adfg=fishingPersonalUse.main, accessed 2021-04-02</j.4:hasDbXref>
+    <owl:annotatedTarget>A regulatory category of Alaskan fishery which is legally defined as, "the taking, fishing for, or possession of finfish, shellfish, or other fishery resources, by Alaska residents for personal use and not for sale or barter, with gill or dip net, seine, fish wheel, long line, or other means defined by the Board of Fisheries." Personal use fisheries may exist only in "nonsubsistence areas" as determined by the state of Alaska (AS 16.05.258(c)).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000175"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A53">
+    <rdf:rest rdf:nodeID="A54"/>
+    <rdf:first rdf:nodeID="A43"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000506">
+    <rdfs:label xml:lang="en">Juvenile standing stock abundance</rdfs:label>
+    <rdfs:comment>An Essential Salmon Variable (ESV) from the working list being developed by Graeme Diack et al. at the Atlantic Salmon Trust.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-29T19:02:18Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000504"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002997">
+    <rdfs:label xml:lang="en">site identifier</rdfs:label>
+    <rdfs:comment>Identifier associated, in some context" with a "Site"-- i.e. a location where some research data have been or are being collected</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-05-23T19:30:55Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000672"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A55">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Coho_salmon, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q934874, accessed 2021-06-15</j.4:hasDbXref>
+    <owl:annotatedTarget>Oncorhynchus kisutch (i.e. coho salmon) is one of the five species of Pacific salmon.
+
+Physical Description: During their ocean phase, coho salmon have silver sides and dark-blue backs. During their spawning phase, their jaws and teeth become hooked. After entering fresh water, they develop bright-red sides, bluish-green heads and backs, dark bellies and dark spots on their backs. Sexually maturing fish develop a light-pink or rose shading along the belly, and the males may show a slight arching of the back. Mature adults have a pronounced red skin color with darker backs and average 28 inches (71 cm) and 7 to 11 pounds (3.2 to 5.0 kg), occasionally reaching up to 36 pounds (16 kg). They also develop a large kype (hooked beak) during spawning. Mature females may be darker than males, with both showing a pronounced hook on the nose.
+
+Range: The traditional range of the coho salmon runs along both sides of the North Pacific Ocean, from Hokkaidō, Japan and eastern Russia, around the Bering Sea to mainland Alaska, and south to Monterey Bay, California. Coho salmon have also been introduced in all the Great Lakes, as well as many landlocked reservoirs throughout the United States. A number of specimens, (more than 20), were caught in waters surrounding Denmark and Norway in 2017. Their source is currently unknown, but the salmon species is farmed at several locations in Europe, making it probable that the animal has slipped the net at such a farm.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000462"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A56">
+    <dc:source>https://en.wikipedia.org/wiki/Atlantic_salmon, accessed 2021-06-01
+https://www.wikidata.org/wiki/Q188879, accessed 2021-06-01</dc:source>
+    <owl:annotatedTarget>Salmo salar
+S. salar</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000586"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A32">
+    <rdf:rest rdf:nodeID="A57"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000582"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A58">
+    <dc:source>https://en.wikipedia.org/wiki/Coastal_cutthroat_trout, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q5138345, accessed 2021-06-15</dc:source>
+    <owl:annotatedTarget>Oncorhynchus clarkii clarkii
+Oncorhynchus c. clarkii
+O. c. clarkii</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000651"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000639">
+    <skos:definition>Group of individuals of a species which can be regarded as an entity for management or assessment purposes; a separate breeding population of a species; term used to identify a management unit of fishery species. A distinct genetic population, a population defined by movement pattern, part of a population potentially harvestable, or a quantity of fish from a given area. May be a total or a spawning stock.</skos:definition>
+    <rdfs:label xml:lang="en">Fish stock type</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-14T23:05:05Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000748">
+    <skos:definition>Total number of recruits of age class 6.4.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 6.4 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:57:59Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000670"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000615">
+    <skos:definition>﻿A classification of fishes which spawn in freshwater, migrate to the ocean to forage and mature, and return to freshwater to spawn and begin the cycle again.</skos:definition>
+    <rdfs:label xml:lang="en">Anadromous</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-01T20:10:58Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000614"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000724">
+    <skos:definition>Total number of recruits of age class 3.7.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 3.7 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:52:32Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000667"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000700">
+    <skos:definition>Total number of recruits of age class 1.5.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 1.5 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:47:26Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000665"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000192">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/ENVO_00000015</skos:exactMatch>
+    <skos:definition>A marine water body which is constitutes the majority of an astronomical body's hydrosphere.</skos:definition>
+    <rdfs:label xml:lang="en">Ocean</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-07T18:39:26Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000203"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A59">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>This identification type will last the entire lifetime of the fish, is used for group marking, and is most suitable for salmonids that are at least 10cm in length.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000543"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A60">
+    <owl:members rdf:nodeID="A61"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A62">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>The number of recruits which survive to a legal age and/or size and are captured by a fishery.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000491"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A63">
+    <dc:source>https://www.wikidata.org/wiki/Q833503, accessed 2021-04-16</dc:source>
+    <dc:source>https://en.wikipedia.org/wiki/Chinook_salmon, accessed 2021-04-16</dc:source>
+    <owl:annotatedTarget>Oncorhynchus tshawytscha
+O. tshawytscha
+"king salmon" @en
+"Quinnat salmon" @en
+"spring salmon" @en
+"chrome hog" @en
+"Blackmouth" @en
+"Tyee salmon" @en</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000239"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A64">
+    <dc:source>https://orcid.org/0000-0002-5300-3075</dc:source>
+    <owl:annotatedTarget>Objective comparative measure of hot or cold of water in a stream.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000219"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A65">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>This type of identification can remain in a fish for several years, is used for individual tagging, and is most suitable for fish that weigh at least 100g (given current technology). Tags may be inserted several different ways: (a) placed in a fish's stomach using a finger or guide, (b) implanted in the abdominal cavity, or (c) anchored inside the abdomen, usually to the abdominal wall with stiches. Data is transmitted wirelessly, usually through the use of radio waves (in fresh water and air), acoustic signals (in water; the receiver must also be in the water) or via satellite communication (in air; the tag sends data after it releases from the fish and floats up to the surface). Many types of telemetry devices also act as bio-loggers and store information locally on the device. Reading is done using the tag’s associated equipment, often through a computer connection.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000534"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000505">
+    <skos:definition>The total number of recruits which successfully return to spawn in freshwater habitats for a given brood year.</skos:definition>
+    <skos:altLabel>adult spawning stock abundance
+adult spawning stock</skos:altLabel>
+    <rdfs:label xml:lang="en">Spawner abundance</rdfs:label>
+    <rdfs:comment>An Essential Salmon Variable (ESV) from the working list being developed by Graeme Diack et al. at the Atlantic Salmon Trust. The ESV list uses the label 'Adult spawning stock abundance' rather than 'Spawner abundance.'</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-29T19:02:08Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000504"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A66">
+    <dc:source>https://spo.nmfs.noaa.gov/sites/default/files/legacy-pdfs/leaflet488.pdf, accessed 2021-04-06</dc:source>
+    <owl:annotatedTarget>There are three basic methods for age and growth determination of fishes: (1) observation of the growth of fishes of known age, (2) study of fish size-frequencies, and (3) study of seasonal ring formation in hard body parts such as scales and bones.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000185"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000529">
+    <skos:definition>An identifier, which may be assigned to a physical sample taken from a fish (e.g. tissue, fin, otolith) or an entire fish specimen.</skos:definition>
+    <rdfs:label xml:lang="en">Fish sample code</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-04T21:55:17Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000528"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A67">
+    <dc:source>http://purl.obolibrary.org/obo/ENVO_00000016</dc:source>
+    <owl:annotatedTarget>A large expanse of saline water usually connected with an ocean.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000204"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000638">
+    <skos:definition>A fish measurement method in which the length from the most anterior tip of the body to the tip of the longest caudal fin rays is recorded.
+Total length can be measured by two conventions -- by leaving the caudal fin spread in a natural position or by compressing the lobes of the caudal fin dorsoventrally. Two common procedures are:
+
+(a) Using a measuring board: A fish is placed on its side on a measuring board with its snout against the rigid headpiece. A measurement is taken from the most anterior tip of the body to the tip of the longest caudal fin rays.
+
+(b) Using a tape measure: A fish is placed on its side, either on top of a tape measure or the tape measure is placed just above the dorsal side of the fish to record the measurement from the most anterior tip of the body to the tip of the longest caudal fin rays. It is important to not allow the tape to curve along the contoured side of the fish that is facing up, which can introduce bias into the measurement due to girth.</skos:definition>
+    <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/SALMON_00000134"/>
+    <rdfs:label xml:lang="en">Total length measurement method</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-14T21:49:03Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000630"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000747">
+    <skos:definition>Total number of recruits of age class 6.3.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 6.3 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:57:51Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000670"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000856">
+    <rdfs:label xml:lang="en">European System Age Designation</rdfs:label>
+    <rdfs:comment>The European Age System Designation is based on a count of Freshwater (FW) and Saltwater (SW) Annuli in recruit otoliths, represented as "number of FW annuli" "." "number of SW annuli", e.g "1.4" indicating 1 FW annulus and 4 SW annuli.
+
+Some interpret the "Total Age" of a recruit with an "Age designation= 0.0"  as a 1-year old salmon, while others interpret "Total Age" as a 0-year old salmon.
+
+That is, in some cases "Total Age" might be reported FW+SW+1, while in other cases it would simply be FW+SW:
+
+1.3=total age of 4, or 5 years
+2.3=total age of 5, or 6 years</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-12-09T20:51:19Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000662"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A68">
+    <rdfs:comment>http://purl.obolibrary.org/obo/GAZ_00000448
+
+https://www.washoeschools.net/cms/lib/NV01912265/Centricity/Domain/1141/Five%20Themes%20of%20Geo%20packet%202017.pdf, accessed 2021-06-22</rdfs:comment>
+    <owl:annotatedTarget>A reference to a position on the Earth, by its name or by its geographical location.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000676"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000614">
+    <rdfs:label xml:lang="en">Migratory pattern</rdfs:label>
+    <rdfs:comment>A broad category that may be useful for classifying fish based on patterns in migratory trajectories.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-01T20:10:50Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A69">
+    <rdf:rest rdf:nodeID="A70"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000126"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A71">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>A numeric or alphanumeric code which represents potential sources of error in determining the age of a fish specimen.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000681"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000723">
+    <skos:definition>Total number of recruits of age class 3.6.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 3.6 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:52:26Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000667"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000191">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/ENVO_00000020</skos:exactMatch>
+    <skos:definition>A body of water or other liquid of considerable size contained in a depression on a landmass.</skos:definition>
+    <rdfs:label xml:lang="en">Lake</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-07T18:39:22Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000197"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A72">
+    <dc:source>https://en.wikipedia.org/wiki/Bismarck_brown_Y, accessed 05May2021</dc:source>
+    <owl:annotatedTarget>Bismarck brown
+Machester brown
+Phenylene brown
+Bismarck brown Y
+C.I. 21000
+C.I. Basic Brown 1
+Basic Brown 1
+Vesuvine BA</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000536"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A73">
+    <rdf:rest rdf:nodeID="A74"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000676"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000504">
+    <rdfs:label xml:lang="en">Salmon abundance</rdfs:label>
+    <rdfs:comment>A measurement or estimate of the number of salmon, based on counts, densities, weights, or other methods.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-29T19:01:14Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000499"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000528">
+    <skos:relatedMatch rdf:resource="http://semanticscience.org/resource/SIO_001050"/>
+    <skos:definition>A numeric or alphanumeric code which represents a particular sample. A sample is defined as a limited quantity of something (e.g. an individual or set of individuals from a population, or a portion of a substance) to be used for testing, analysis, inspection, investigation, demonstration, or trial use.</skos:definition>
+    <skos:altLabel>sample id</skos:altLabel>
+    <rdfs:label xml:lang="en">Sample code</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-04T21:54:57Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000572"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000419">
+    <rdfs:label xml:lang="en">Subsurface sea temperature</rdfs:label>
+    <rdfs:comment>An Essential Salmon Variable (ESV) from the working list being developed by Graeme Diack et al. at the Atlantic Salmon Trust.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-22T17:20:03Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000412"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A75">
+    <dc:source>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</dc:source>
+    <owl:annotatedTarget>The flap in the corner of the mouth is clipped away (the maxilla - sometimes also the supermaxilla).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000543"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000637">
+    <skos:definition>A fish measurement method in which the length from the most anterior tip of the body to the midlateral posterior edge of the hypural plate (in fish with a hypural plate) or to the posterior end of the vertebral column (in fish lacking hypural plates) is recorded. Two common procedures are:
+
+(a) Using a measuring board: A fish is placed on its side on a measuring board with its snout against the rigid headpiece. A measurement is taken from the most anterior tip of the body to the midlateral posterior edge of the hypural plate (in fish with a hypural plate) or to the posterior end of the vertebral column (in fish lacking hypural plates).
+
+(b) Using a tape measure: A fish is placed on its side, either on top of a tape measure or the tape measure is placed just above the dorsal side of the fish to record the measurement from the most anterior tip of the body to the midlateral posterior edge of the hypural plate (in fish with a hypural plate) or to the posterior end of the vertebral column (in fish lacking hypural plates). It is important to not allow the tape to curve along the contoured side of the fish that is facing up, which can introduce bias into the measurement due to girth.</skos:definition>
+    <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/SALMON_00000135"/>
+    <rdfs:label xml:lang="en">Standard length measurement method</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-14T21:45:52Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000630"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A76">
+    <dc:source>https://www.researchgate.net/profile/Darlene-Gillespie/publication/281285926_Chinook_Salmon_Oncorhynchus_tshawytscha_Scale_Age_Determination_Procedures/links/55df66d708aede0b572b8de7/Chinook-Salmon-Oncorhynchus-tshawytscha-Scale-Age-Determination-Procedures.pdf, accessed 20212-04-09</dc:source>
+    <owl:annotatedTarget>An age designation notation that includes two number separated by a period. The first number represents the number of years or winters a salmon has spent in freshwater after emergence from the gravel, and the second number represents the number of years spent in the ocean. Added together, these numbers can provide the total age or age class of a salmon. (although see Comment for further detail).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000200"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000746">
+    <skos:definition>Total number of recruits of age class 6.2.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 6.2 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:57:46Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000670"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A77">
+    <dc:source>Schiewe, MH (2013) Salmon. Encyclopedia of Biodiversity (Second Edition). pg. 522-531. https://doi.org/10.1016/B978-0-12-384719-5.00293-8</dc:source>
+    <owl:annotatedTarget>Atlantic salmon are the only anadromous salmonid native to the Atlantic coast of North America.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000586"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002070">
+    <skos:altLabel>second of hour</skos:altLabel>
+    <rdfs:label xml:lang="en">second of measurement time</rdfs:label>
+    <j.4:hasExactSynonym>second of hour</j.4:hasExactSynonym>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-16T00:29:24Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002040"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000613">
+    <skos:definition>A reproductive strategy which is characterized by a single reproductive episode, typically before death.</skos:definition>
+    <rdfs:label xml:lang="en">Semelparity</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-01T20:04:35Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000611"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A78">
+    <j.4:hasDbXref>https://www.monitoringresources.org/Document/Method/Details/1549, accessed 2021-06-14
+https://www.monitoringresources.org/Document/Method/Details/4041, accessed 2021-06-14</j.4:hasDbXref>
+    <owl:annotatedTarget>A fish measurement method in which the length from the middle of the orbit to the tip of the median caudal fin rays is recorded. Two common procedures are:
+
+(a) Using a measuring board: A fish is placed on its side on a measuring board with its snout against the rigid headpiece. A measurement is taken from the middle of the orbit (i.e. eye) to the tip of the median caudal fin rays (i.e. fork).
+
+(b) Using a tape measure: A fish is placed on its side, either on top of a tape measure or the tape measure is placed just above the dorsal side of the fish to record the measurement from the middle of the orbit (i.e. eye) to the tip of the median caudal fin rays (i.e. fork). It is important to not allow the tape to curve along the contoured side of the fish that is facing up, which can introduce bias into the measurement due to girth.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000632"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000722">
+    <skos:definition>Total number of recruits of age class 3.5.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 3.5 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:52:22Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000667"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000855">
+    <rdfs:label xml:lang="en">European system Age designation recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-12-09T20:48:48Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000663"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000190">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/ENVO_00000022</skos:exactMatch>
+    <skos:definition>A stream which, through permanent or seasonal flow processes, moves from elevated land towards lower elevations through a definite channel and empties either into a sea, lake, or another river or ends on land as bed seepage and evapotranspiration exceed water supply.</skos:definition>
+    <rdfs:label xml:lang="en">River</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-07T18:39:18Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000194"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#closeMatch">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A79">
+    <dc:source>http://www.adfg.alaska.gov/index.cfm?adfg=fishingPersonalUse.main, accessed 2021-04-02</dc:source>
+    <owl:annotatedTarget>Personal use fishing is open to Alaskan residents only, and you must have a valid resident Sport Fishing License to participate in personal use fisheries.
+
+The bag, possession, and gear limits in personal use fisheries MAY NOT be added to the bag, possession, and gear limits under sport or subsistence regulations.
+
+It is unlawful to buy, sell, trade or barter personal use finfish, shellfish, aquatic plants, or their parts.
+
+Many, but not all, personal use fisheries require a permit issued by the Department of Fish and Game. Personal use fisheries have many different regulations for bag limits, allowable gear, and time and area restrictions. Some personal use fisheries are managed in-season by emergency order, so regulations can change at any time.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000175"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000721">
+    <skos:definition>Total number of recruits of age class 3.4.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 3.4 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:52:16Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000667"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000830">
+    <rdfs:label xml:lang="en">Geocoordinates</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-12T20:54:42Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000675"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#prefLabel">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000503">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/PCO_0000004</skos:exactMatch>
+    <skos:definition>A quality that inheres in a community.</skos:definition>
+    <rdfs:label xml:lang="en">Quality of an ecological community</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-29T18:48:45Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#MeasurementType"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000527">
+    <skos:definition>The Alaska Department of Fish and Game defines unique two-digit "Codes for the Commercial Operator's Annual Report" which represent each of the gear types and harvest methods used Alaskan fisheries.</skos:definition>
+    <skos:altLabel>Alaska Department of Fish and Game gear code</skos:altLabel>
+    <rdfs:label xml:lang="en">ADF&amp;G gear code</rdfs:label>
+    <rdfs:comment>ADF&amp;G gear codes:
+
+01 purse seine
+02 beach seine
+03 drift gillnet
+04 set gillnet
+05 hand line/jig/troll
+07 non-pelagic/bottom trawl
+08 fish wheel
+10 ring net
+11 diving
+12 handpicked
+13 dip net
+14 weir
+15 power gurdy troll
+17 beam trawl
+18 shovel
+21 pound
+22 dredge
+23 hydro/mechanical dredge
+25 dinglebar
+26 mechanical jigs
+27 double otter trawl
+34 herring gillnet
+37 pair trawl
+41 sunken gillnet
+47 pelagic/mid-water trawl
+61 longline (hook and line)
+77 fish ladder/raceway
+90 trap
+91 pot gear
+99 other (please specify)</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-04T19:58:32Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000526"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A80">
+    <dc:source>http://purl.obolibrary.org/obo/ENVO_00000033</dc:source>
+    <owl:annotatedTarget>A body of water, usually of smaller size than a lake.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000198"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000878">
+    <rdfs:label xml:lang="en">Places and Locations</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2022-01-27T20:37:47Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000769">
+    <skos:definition>Total number of recruits of age class 8.5.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 8.5 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T19:36:20Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000755"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000636">
+    <skos:definition>A fish measurement method in which the length from the hind margin of the orbit (i.e. eye) to the hypural plate is recorded. Two common procedures are:
+
+(a) Using a measuring board: A fish is placed on its side on a measuring board with its snout against the rigid headpiece. A measurement is taken from hind margin of the orbit (i.e. eye) to the hypural plate.
+
+(b) Using a tape measure: A fish is placed on its side, either on top of a tape measure or the tape measure is placed just above the dorsal side of the fish to record the measurement from the hind margin of the orbit (i.e. eye) to the hypural plate. It is important to not allow the tape to curve along the contoured side of the fish that is facing up, which can introduce bias into the measurement due to girth.
+
+In the case that hypural plate is not visible, the measurement may be made to some external feature (e.g. the position of the last lateral line scale; end of the fleshy caudal peduncle; midline of a crease that forms when the tail is bent sharply). It is important to note this adjustment in measurement protocol.</skos:definition>
+    <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/SALMON_00000130"/>
+    <rdfs:label xml:lang="en">Post-orbit to hypural plate measurement method</rdfs:label>
+    <dc:description>Measurements of specific parts of a fish are sometimes necessary when intact fish are not available. For instance, spawning or dead salmon often have eroded tails (from redd excavation) or enlarged or damaged jaws. When researchers want to compare fish lengths of male spawners versus female spawners or hatchery spawned females versus carcasses, it is a good idea to use this type of length measurement to remove the bias of the eroded tails on female spawners. So length measurements are made from specific parts of the body that are intact, such as the orbit and the hypural plate. The hypural plate is comprised of modified vertebrae that support the rays of the caudal fin and originate from the posterior end of the vertebral column.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-14T21:38:35Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000630"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000745">
+    <skos:definition>Total number of recruits of age class 6.1.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 6.1 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:57:39Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000670"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000612">
+    <skos:definition>A reproductive strategy which is characterized by multiple reproductive cycles over the course of an organism's lifetime.</skos:definition>
+    <rdfs:label xml:lang="en">Iteroparity</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-01T20:04:29Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000611"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A81">
+    <dc:source>http://purl.obolibrary.org/obo/MMO_0000000</dc:source>
+    <owl:annotatedTarget>The manner, procedure or technique by which a morphological or physiological state or property in a single individual or sample or a group of individuals or samples is assessed and a quantitative or qualitative value assigned.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000205"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A82">
+    <dc:source>https://spo.nmfs.noaa.gov/sites/default/files/legacy-pdfs/leaflet488.pdf, accessed 2021-04-27</dc:source>
+    <owl:annotatedTarget>Otoliths, or "earstones" (structures formed of calcium in the heads of bony fishes, and which function as organs of balance), grow concentrically from the center origin. Factors, such as watertemperature, that affect fish growth cause seasonal changes in the density of layers laid down in otoliths and in some cases it is possible to determine fish age from the banding that results. When otoliths are viewed under a low-power microscope, the layers making up spring and summer growth appear as a white, opaque band. Layers laid down in the fall, and also in the winter in some fishes, appear as a dark translucent band. A light and a dark band together make up the annual growth, and age in years is determined by counting the number of dark bands.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000483"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A83">
+    <dc:source>http://purl.obolibrary.org/obo/ENVO_00000476</dc:source>
+    <owl:annotatedTarget>An opening of a lake into its shore.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000228"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000502">
+    <rdfs:label xml:lang="en">Pre-fishery abundance</rdfs:label>
+    <rdfs:comment>[ADDRESS COMMENT, THEN DELETE]
+
+needs defintion</rdfs:comment>
+    <rdfs:comment>An Essential Salmon Variable (ESV) from the working list being developed by Graeme Diack et al. at the Atlantic Salmon Trust.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-29T18:44:25Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000501"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000611">
+    <rdfs:label xml:lang="en">Reproductive strategy</rdfs:label>
+    <rdfs:comment>A general category for gathering traits (morphological, behavioral, and otherwise) that have some evolutionary basis for achieving reproductive success.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-01T20:04:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000720">
+    <skos:definition>Total number of recruits of age class 3.3.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 3.3 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:52:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000667"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000526">
+    <skos:definition>A numeric or alphanumeric code, which represents a particular type of fishing gear or equipment.</skos:definition>
+    <rdfs:label xml:lang="en">Fishing gear code</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-04T19:58:20Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000672"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000417">
+    <skos:exactMatch>http://purl.dataone.org/odo/ECSO_00001658</skos:exactMatch>
+    <skos:definition>Salinity measured at the surface of the sea. The exact meaning of surface varies according to the measurement method used, but it is between 1 millimetre (0.04 in) and 20 metres (70 ft) below the sea surface.</skos:definition>
+    <rdfs:label xml:lang="en">Sea surface salinity</rdfs:label>
+    <rdfs:comment>Is also an Essential Salmon Variable (ESV) from the working list being developed by Graeme Diack et al. at the Atlantic Salmon Trust.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-22T17:17:30Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000416"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#definition">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000112">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000659">
+    <skos:definition>The weight of a fish, typically taken when the specimen is still alive or freshly deceased, but before being frozen or further processed.</skos:definition>
+    <rdfs:label xml:lang="en">Wet weight</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-16T22:53:55Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000683"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002072">
+    <rdfs:label xml:lang="en">year and day of measurement</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-16T00:44:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002043"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000768">
+    <skos:definition>Total number of recruits of age class 8.4.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 8.4 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T19:36:14Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000755"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000635">
+    <skos:definition>A fish measurement method in which the length from the hind margin of the orbit (i.e. eye) to the tip of the median caudal fin rays (i.e. fork) is recorded. Two common procedures are:
+
+(a) Using a measuring board: A fish is placed on its side on a measuring board with its snout against the rigid headpiece. A measurement is taken from hind margin of the orbit (i.e. eye) to the tip of the median caudal fin rays (i.e. fork).
+
+(b) Using a tape measure: A fish is placed on its side, either on top of a tape measure or the tape measure is placed just above the dorsal side of the fish to record the measurement from the hind margin of the orbit (i.e. eye) to the tip of the median caudal fin rays (i.e. fork). It is important to not allow the tape to curve along the contoured side of the fish that is facing up, which can introduce bias into the measurement due to girth.</skos:definition>
+    <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/SALMON_00000129"/>
+    <rdfs:label xml:lang="en">Post-orbit to fork of tail measurement method</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-14T21:30:14Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000630"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000744">
+    <skos:definition>Total number of recruits of age class 5.5.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 5.5 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:57:19Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000669"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#narrowMatch">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A84">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Recreational_fishing, accessed 2021-04-02
+https://www.wikidata.org/wiki/Q283534, accessed 2021-04-02</j.4:hasDbXref>
+    <owl:annotatedTarget>A fishery in which fishes and other seafood are harvested for pleasure or competition.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000170"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A85">
+    <dc:source>http://purl.obolibrary.org/obo/ENVO_00000020</dc:source>
+    <owl:annotatedTarget>A body of water or other liquid of considerable size contained in a depression on a landmass.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000191"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000743">
+    <skos:definition>Total number of recruits of age class 5.9.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 5.9 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:56:26Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000669"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000525">
+    <skos:definition>The Alaska Department of Fish and Game defines unique three-digit "Codes for the Commercial Operator's Annual Report" which represent each of the commercially harvested aquatic species.</skos:definition>
+    <skos:altLabel>Alaska Department of Fish and Wildlife species code</skos:altLabel>
+    <rdfs:label xml:lang="en">ADF&amp;G species code</rdfs:label>
+    <rdfs:comment>ADF&amp;G salmon species codes:
+
+410 salmon, chinook
+420 salmon, sockeye
+430 salmon, coho
+440 salmon, pink
+450 salmon, chum</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-04T19:44:10Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000523"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000416">
+    <skos:exactMatch>http://purl.dataone.org/odo/ECSO_00001164</skos:exactMatch>
+    <skos:definition>A measure of the saltiness or dissolved salt content of a body of water.</skos:definition>
+    <rdfs:label xml:lang="en">Water salinity measurement type</rdfs:label>
+    <dc:description>Salinity is an important factor in determining many aspects of the chemistry of natural waters and of biological processes within it, and is a thermodynamic state variable that, along with temperature and pressure, governs physical characteristics like the density and heat capacity of the water.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-22T17:00:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000214"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000549">
+    <skos:definition>A barbed plastic tag which is inserted under the dorsal fin of the fish using a cannula.</skos:definition>
+    <rdfs:label xml:lang="en">Dart tag</rdfs:label>
+    <dc:description>If performed correctly, this type of identification can remain in place for at least a year, is used for individual tagging, and is suitable for fish at lest 20cm in length and which live in open environments. With the cannula attached to a special tag applicator, a scale is removed just below the base of the dorsal fin and the tag is attached. The barb on the tag must hook securely into the pterygiophores (the bones that supports the dorsal fin), otherwise the tag will come loose. Most of the tag then hangs outside the fish’s body like a stiff, narrow tube. The tag is colour-coded, pre-printed with relevant text and numbered by the manufacturer according to the requests of the end user.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:43:07Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000547"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000658">
+    <skos:altLabel>fish weight
+weight of fish
+fish mass
+mass of fish</skos:altLabel>
+    <rdfs:label xml:lang="en">Fish weight measurement type</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-16T22:45:21Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000167"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000767">
+    <skos:definition>Total number of recruits of age class 8.3.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 8.3 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T19:36:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000755"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/license">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000501">
+    <rdfs:label xml:lang="en">Modeled salmon abundance</rdfs:label>
+    <rdfs:comment>Abundance of salmon estimated from modeling techniques, rather than direct counts, weights, etc.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-29T18:39:15Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000504"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000634">
+    <skos:definition>A fish measurement method in which the length from the middle of the orbit (i.e. eye) to the the posterior-most point where the fin connects with the body is recorded. Two common procedures are:
+
+(a) Using a measuring board: A fish is placed on its side on a measuring board with its snout against the rigid headpiece. A measurement is taken from the middle of the orbit (i.e. eye) to the posterior-most point where the fin connects with the body.
+
+(b) Using a tape measure: A fish is placed on its side, either on top of a tape measure or the tape measure is placed just above the dorsal side of the fish to record the measurement from the middle of the orbit (i.e. eye) to the posterior-most point where the fin connects with the body. It is important to not allow the tape to curve along the contoured side of the fish that is facing up, which can introduce bias into the measurement due to girth.</skos:definition>
+    <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/SALMON_00000132"/>
+    <rdfs:label xml:lang="en">Mid-orbit to posterior insertion of anal fin measurement method</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-14T21:17:24Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000630"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A86">
+    <dc:source>https://www.adfg.alaska.gov/static/license/fishing/pdfs/coar_fish_codes.pdf, accessed 04May2021</dc:source>
+    <owl:annotatedTarget>ADF&amp;G gear codes:
+
+01 purse seine
+02 beach seine
+03 drift gillnet
+04 set gillnet
+05 hand line/jig/troll
+07 non-pelagic/bottom trawl
+08 fish wheel
+10 ring net
+11 diving
+12 handpicked
+13 dip net
+14 weir
+15 power gurdy troll
+17 beam trawl
+18 shovel
+21 pound
+22 dredge
+23 hydro/mechanical dredge
+25 dinglebar
+26 mechanical jigs
+27 double otter trawl
+34 herring gillnet
+37 pair trawl
+41 sunken gillnet
+47 pelagic/mid-water trawl
+61 longline (hook and line)
+77 fish ladder/raceway
+90 trap
+91 pot gear
+99 other (please specify)</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000527"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000633">
+    <skos:definition>A fish measurement method in which the length from the middle of the orbit (i.e. eye) to the hypural plate is recorded. Two common procedures are:
+
+(a) Using a measuring board: A fish is placed on its side on a measuring board with its snout against the rigid headpiece. A measurement is taken from the middle of the orbit (i.e. eye) to the hypural plate.
+
+(b) Using a tape measure: A fish is placed on its side, either on top of a tape measure or the tape measure is placed just above the dorsal side of the fish to record the measurement from the middle of the orbit (i.e. eye) to the hypural plate. It is important to not allow the tape to curve along the contoured side of the fish that is facing up, which can introduce bias into the measurement due to girth.
+
+In the case that hypural plate is not visible, the measurement may be made to some external feature (e.g. the position of the last lateral line scale; end of the fleshy caudal peduncle; midline of a crease that forms when the tail is bent sharply). It is important to note this adjustment in measurement protocol.</skos:definition>
+    <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/SALMON_00000131"/>
+    <rdfs:label xml:lang="en">Mid-orbit to hypural plate measurement method</rdfs:label>
+    <dc:description>Measurements of specific parts of a fish are sometimes necessary when intact fish are not available. For instance, spawning or dead salmon often have eroded tails (from redd excavation) or enlarged or damaged jaws. When researchers want to compare fish lengths of male spawners versus female spawners or hatchery spawned females versus carcasses, it is a good idea to use this type of length measurement to remove the bias of the eroded tails on female spawners. So length measurements are made from specific parts of the body that are intact, such as the orbit and the hypural plate. The hypural plate is comprised of modified vertebrae that support the rays of the caudal fin and originate from the posterior end of the vertebral column. This measurement is also commonly referred to as MEPS, or mid-eye to posterior scale, noting that researchers typically take the measurement to an external feature when the hypural plate is not visible.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-14T21:08:39Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000630"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000524">
+    <skos:definition>The unique alphanumeric code or marking color(s) of a tagged fish.</skos:definition>
+    <rdfs:label xml:lang="en">Fish tag code or color</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-04T19:41:34Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000672"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000742">
+    <skos:definition>Total number of recruits of age class 5.8.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 5.8 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:56:21Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000669"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000415">
+    <rdfs:comment>An Essential Salmon Variable (ESV) from the working list being developed by Graeme Diack et al. at the Atlantic Salmon Trust.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-22T16:49:49Z</dc:date>
+    <rdfs:label xml:lang="en">Sea surface temperature</rdfs:label>
+    <skos:altLabel>SST
+Ocean surface temperature</skos:altLabel>
+    <skos:exactMatch rdf:resource="http://purl.obolibrary.org/obo/ENVO_04000002"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <skos:exactMatch>http://purl.dataone.org/odo/ECSO_00001523</skos:exactMatch>
+    <skos:definition>An aquatic temperature which inheres in water close to the surface of an ocean or sea. The exact meaning of surface varies according to the measurement method used, but it is between 1 millimetre (0.04 in) and 20 metres (70 ft) below the sea surface.</skos:definition>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000412"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000548">
+    <rdfs:label xml:lang="en">Carlin tag</rdfs:label>
+    <dc:description>If performed correctly, this identification type may remain attached for the entire life of the fish, is used for individual tagging, and is most suitable for fish at least 15cm in length and which live in open environments. To attach a Carlin tag, double cannulas are first inserted through the fish at the height of the center of the pterygiophores (the bones that support the dorsal fin). Two stainless steel wires are then pulled through the cannulas and then the cannulas are pulled out of the fish. A small metal plate with an alphanumeric code is atached to the steel wires, which are then twisted tightly against the fish's body to hold the plate in place.</dc:description>
+    <dc:description>A metal plate with a unique identifying code, which is attached to a fish below the dorsal fin via two stainless steel wires.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:40:41Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000547"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A87">
+    <j.4:hasDbXref>https://www.adfg.alaska.gov/index.cfm?adfg=fishingsubsistence.main, accessed 2021-04-02</j.4:hasDbXref>
+    <owl:annotatedTarget>A fishery in which fishes or other seafood are harvested for noncommercial, customary and traditional uses. These uses include direct personal or family consumption as food, shelter, fuel, clothing, tools, or transportation, for the making and selling of handicraft articles out of nonedible by-products of fish and wildlife resources taken for personal or family consumption, and for the customary trade, barter, or sharing for personal or family consumption.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000172"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#exactMatch">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A88">
+    <dc:source>https://www.monitoringresources.org/Document/Method/Details/4041, accessed 2021-06-14</dc:source>
+    <owl:annotatedTarget>A fish measurement method in which the length from the most anterior part of a fish to the tip of the median caudal fin rays (i.e. fork) is recorded. Two common procedures are:
+
+(a) Using a measuring board: A fish is placed on its side on a measuring board with its snout against the rigid headpiece. A measurement is taken from the most anterior part to the tip of the median caudal fin rays (i.e. fork).
+
+(b) Using a tape measure: A fish is placed on its side, either on top of a tape measure or the tape measure is placed just above the dorsal side of the fish to record the measurement from the most anterior part to the tip of the median caudal fin rays (i.e. fork). It is important to not allow the tape to curve along the contoured side of the fish that is facing up, which can introduce bias into the measurement due to girth.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000631"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002050">
+    <rdfs:label xml:lang="en">year of measurement</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-14T23:23:43Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002043"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000657">
+    <skos:definition>Brood tables, also called run reconstructions, utilize annual estimates of the total run (commercial catch plus escapement), and samples of ages, to estimate the number of recruits per age class. These data are useful for salmon biologists to understand salmon productivity and salmon life histories.</skos:definition>
+    <skos:altLabel>run reconstruction</skos:altLabel>
+    <rdfs:label xml:lang="en">Brood table</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-16T22:33:58Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000656"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000766">
+    <skos:definition>Total number of recruits of age class 8.2.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 8.2 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T19:36:04Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000755"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A89">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>Natural patterns or unique markings are primarily used for identification of individuals. This type of identification does not involve marking a fish in any way, but rather relies on stable and individual differences in appareance, such as color, patterns, and scars. This method is based on the use of still images or videos taken of individual fish, which are then analyzed manually or using digital image processing.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000552"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A90">
+    <dc:source rdf:resource="http://purl.obolibrary.org/obo/PCO_0000019"/>
+    <owl:annotatedTarget>The number of different species that are represented in a given community, weighted by their abundance. Community species diversity can be calculated in different ways, but consists of two components: species richness and species evenness.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000624"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A91">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>The weight of a specimen's stomach, taken after the stomach has been dissected from the fish and emptied of its contents.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000686"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A92">
+    <j.4:hasDbXref>https://www.fisheries.noaa.gov/species/pacific-salmon-and-steelhead#overview, accessed  2021-06-01</j.4:hasDbXref>
+    <j.4:hasDbXref>Schiewe, MH (2013) Salmon. Encyclopedia of Biodiversity (Second Edition). pg. 522-531. https://doi.org/10.1016/B978-0-12-384719-5.00293-8</j.4:hasDbXref>
+    <owl:annotatedTarget>There are five species of Pacific salmon, which occur in the North Pacific waters of the United States and Canada -- Chinook, Chum, Coho, Pink, and Sockeye. All five species are anadromous, meaning that they spawn in freshwater, migrate to the ocean to forage and mature, and return to freshwater to spawn and begin the cycle again.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000414">
+    <skos:exactMatch>http://purl.dataone.org/odo/ECSO_00001231</skos:exactMatch>
+    <skos:definition>Objective comparative measure of hot or cold of water in a lake.</skos:definition>
+    <rdfs:label xml:lang="en">Lake water temperature</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-22T16:36:05Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000411"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000765">
+    <skos:definition>Total number of recruits of age class 8.1.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 8.1 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T19:35:56Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000755"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000547">
+    <skos:definition>A static tag, which is attached externally to the body of the fish and visually read or interpreted (as opposed to read with an electronic device e.g. an acoustic tag reader).</skos:definition>
+    <rdfs:label xml:lang="en">External visual tag</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:40:28Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000530"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000632">
+    <skos:definition>A fish measurement method in which the length from the middle of the orbit to the tip of the median caudal fin rays is recorded. Two common procedures are:
+
+(a) Using a measuring board: A fish is placed on its side on a measuring board with its snout against the rigid headpiece. A measurement is taken from the middle of the orbit (i.e. eye) to the tip of the median caudal fin rays (i.e. fork).
+
+(b) Using a tape measure: A fish is placed on its side, either on top of a tape measure or the tape measure is placed just above the dorsal side of the fish to record the measurement from the middle of the orbit (i.e. eye) to the tip of the median caudal fin rays (i.e. fork). It is important to not allow the tape to curve along the contoured side of the fish that is facing up, which can introduce bias into the measurement due to girth.</skos:definition>
+    <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/SALMON_00000133"/>
+    <rdfs:label xml:lang="en">Mid-orbit to fork of tail measurement method</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-14T20:58:33Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000630"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002627">
+    <rdfs:label xml:lang="en">years elapsed</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-07-15T23:41:07Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002068"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000741">
+    <skos:definition>Total number of recruits of age class 5.7.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 5.7 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:56:12Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000669"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A93">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>Elapsed time, typically expressed in years, (a) since birth or (b) which describes the how long a salmon has spent in a particular environment (e.g. saltwater vs. freshwater).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000407"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A94">
+    <owl:members rdf:nodeID="A95"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A96">
+    <dc:source>http://www.fishbase.us/glossary/Glossary.php?q=egg&amp;language=english&amp;sc=is, accessed 2021-06-15</dc:source>
+    <owl:annotatedTarget>In fish, the term egg usually refers to female haploid gametes.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000402"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A97">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Abiotic_component, accessed 2021-04-14
+https://www.wikidata.org/wiki/Q461335, accessed 2021-06-14</j.4:hasDbXref>
+    <owl:annotatedTarget>A measurement type taken of some non-living chemical or physical component of the environment.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000214"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000523">
+    <skos:definition>A numeric or alphanumeric code, which represents a particular species and may be recorded in place of a formal scientific or vernacular name.</skos:definition>
+    <rdfs:label xml:lang="en">Species code</rdfs:label>
+    <rdfs:comment>[NEEDS ALIGNMENT]
+
+http://purl.dataone.org/odo/ECSO_00002490</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-04T19:41:18Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000672"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000656">
+    <rdfs:label xml:lang="en">Dataset type</rdfs:label>
+    <rdfs:comment>Class intended to facilitate search by "dataset type"</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-16T22:33:55Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A98">
+    <dc:source rdf:resource="https://www.wikidata.org/wiki/Q44064"/>
+    <dc:source rdf:resource="https://en.wikipedia.org/wiki/Sockeye_salmon"/>
+    <owl:annotatedTarget>Oncorhynchus nerka
+O. nerka
+"red salmon" @en
+"kokanee" @en
+"kokanee salmon" @en
+"blueback salmon" @en
+"blue-back" @en
+"Fraser River salmon" @en
+"redfish" @en
+"sock-eye salmon" @en
+"sox" @en</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000242"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A99">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>A small, electronic, sound-emitting device which may be placed inside or attached to a fish and collects information on that fish's physiology, environmentm and/or movement patterns.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000558"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000480">
+    <skos:definition>The number of salmon from a given population that escape the fishery in a year.</skos:definition>
+    <rdfs:label xml:lang="en">Annual escapement count</rdfs:label>
+    <rdfs:comment>Need to think more about how to model time over which measurement is taken. E.g. do we want to have separate terms for annual escapement counts vs. daily escapement counts, OR have a predicate which encapsulates the time period over which a measurement occurs, OR something else?</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-26T23:24:51Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000479"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000708">
+    <skos:definition>Total number of recruits of age class 0.9.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 0.9 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:49:12Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000664"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A100">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Temperature, accessed 2021-04-22
+https://www.wikidata.org/wiki/Q11466, accessed 2021-04-22</j.4:hasDbXref>
+    <owl:annotatedTarget>The objective measure of hot or cold of water in a river.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000413"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00001597">
+    <rdfs:label xml:lang="en">estuary name</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-05-20T21:33:57Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002768"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.geneontology.org/formats/oboInOwl#default-namespace">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2006/time#hasBeginning">
+    <skos:definition>Beginning of a temporal entity.</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A101">
+    <rdf:rest rdf:nodeID="A34"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000464"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000154">
+    <skos:definition>The gathering live or deceased fishes by hand.</skos:definition>
+    <rdfs:label xml:lang="en">Handpicked or carcass collection</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T18:02:25Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000164"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000152">
+    <skos:definition>A net or mesh basket held open by a hoop which may or may not be on the end of a handle and is used for scopping fish near the surface of the water.</skos:definition>
+    <skos:altLabel>hand net
+scoop net</skos:altLabel>
+    <rdfs:label xml:lang="en">Dip net</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T18:01:59Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000164"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://schema.org/CreativeWork">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A102">
+    <rdfs:comment>Chose not to assert owl:equivalentClass here, because all Steelhead trout are Oncorhynchus mykiss, but not all Oncorhynchus mykiss are considered Steelhead trout.</rdfs:comment>
+    <owl:annotatedTarget rdf:resource="http://purl.dataone.org/odo/SALMON_00000570"/>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000591"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A103">
+    <j.4:hasDbXref>https://fishbio.com/field-notes/inside-fishbio/spray-on-tan, accessed 05May2021</j.4:hasDbXref>
+    <owl:annotatedTarget>This type of identification can remain on a fish from a couple days up to several weeks, and is used for group marking. and is most suitable for fish</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000536"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A104">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>The use of a DNA sample to identify fish which have known biomarkers.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000533"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A105">
+    <dc:source>http://purl.obolibrary.org/obo/ENVO_00000015</dc:source>
+    <owl:annotatedTarget>A marine water body which is constitutes the majority of an astronomical body's hydrosphere.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000192"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A106">
+    <dc:source>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</dc:source>
+    <owl:annotatedTarget>One of the pelvic fins is removed using scissors.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000544"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000707">
+    <skos:definition>Total number of recruits of age class 0.8.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 0.8 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:49:01Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000664"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A107">
+    <dc:source>https://nceas.github.io/sasap-training/materials/reproducible_research_in_r_fairbanks/example-brood-table-analysis.html, accessed 2021-06-16</dc:source>
+    <owl:annotatedTarget>Brood tables, also called run reconstructions, utilize annual estimates of the total run (commercial catch plus escapement), and samples of ages, to estimate the number of recruits per age class. These data are useful for salmon biologists to understand salmon productivity and salmon life histories.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000657"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A108">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Taxonomy_(biology), accessed 2021-04-28</j.4:hasDbXref>
+    <owl:annotatedTarget>The name of the scientist or scientists who first validly published the scientific name of a particular organism.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000495"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000151">
+    <skos:definition>A seine net operated from the shore. The gear is composed of a bunt (bag or lose netting) and long wings often lengthened with long ropes for towing the seine to the beach. The headrope with floats is on the surface, the footrope is in permanent contact with the bottom and the seine is therefore a barrier which prevent the fish from escaping from the area enclosed by the net</skos:definition>
+    <skos:closeMatch rdf:resource="http://vocab.nerc.ac.uk/collection/M13/current/015/"/>
+    <rdfs:label xml:lang="en">Beach seine</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T18:01:54Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000162"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A109">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <owl:intersectionOf rdf:nodeID="A53"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A110">
+    <dc:source>https://en.wikipedia.org/wiki/Johann_Julius_Walbaum, accessed 2021-04-26
+https://www.wikidata.org/wiki/Q68096, accessed 2021-04-26</dc:source>
+    <owl:annotatedTarget>Johann Julius Walbaum (30 June 1724, Wolfenbüttel, Brunswick-Wolfenbüttel – 21 August 1799, Lübeck) was a German physician, naturalist and fauna taxonomist.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000475"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000706">
+    <skos:definition>Total number of recruits of age class 0.7.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 0.7 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:48:49Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000664"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A111">
+    <j.4:hasDbXref>https://fishbio.com/field-notes/inside-fishbio/spray-on-tan, accessed 2021-05-05
+https://en.wikipedia.org/wiki/Bismarck_brown_Y, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>Tag based on application of a dilution of diazo dye in which fish are immersed and which stains the fins a brown/tan color.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000536"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002882">
+    <rdfs:label xml:lang="en">milliseconds elapsed</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-05-07T21:18:21Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002054"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000176">
+    <rdfs:label xml:lang="en">Aquaculture</rdfs:label>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-02T22:18:14Z</dc:date>
+    <skos:definition>The culturing of fish, shellfish, aquatic plants, and/or other organisms in captivity or under controlled conditions in the near shore environment.</skos:definition>
+    <skos:closeMatch>http://vocab.nerc.ac.uk/collection/M13/current/018/</skos:closeMatch>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000639"/>
+    <skos:altLabel>Aquatic farming
+Aquafarming</skos:altLabel>
+    <dc:description>In Alaska, the aquaculture industry primarily produces Pacific oysters, littleneck clams, and mussels for commercial food production.</dc:description>
+    <skos:closeMatch rdf:resource="http://vocab.nerc.ac.uk/collection/M13/current/020/"/>
+    <skos:closeMatch rdf:resource="http://vocab.nerc.ac.uk/collection/M13/current/019/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000900">
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000461"/>
+    <rdfs:label xml:lang="en">Keta salmon</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2022-03-24T19:58:28Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A112">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>A tag which transmits information about a fish via an electronic receiver.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000545"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A46">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000243"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000150">
+    <skos:definition>A three-dimensional wire or wood device which is submerged and commonly baited. A pot (or "trap") permits organisms to enter the enclosure, but makes escape extremely difficult or impossible.</skos:definition>
+    <skos:altLabel>trap</skos:altLabel>
+    <rdfs:label xml:lang="en">Pot</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T18:01:50Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000142"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A113">
+    <rdfs:comment>This URI does not appear to dereference to the term. Including this URL, https://bioportal.bioontology.org/ontologies/NCIT?p=classes&amp;conceptid=http%3A%2F%2Fncicb.nci.nih.gov%2Fxml%2Fowl%2FEVS%2FThesaurus.owl%23C28421, to ensure findability.</rdfs:comment>
+    <owl:annotatedTarget>http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C28421</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#closeMatch"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000216"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A114">
+    <dc:source>https://en.wikipedia.org/wiki/Dolly_Varden_trout, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q327067, accessed 2021-06-15</dc:source>
+    <owl:annotatedTarget>Salvelinus malma
+S. malma
+"Dolly Varden" @en</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000569"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A115">
+    <dc:source>http://purl.dataone.org/odo/ECSO_00001104</dc:source>
+    <owl:annotatedTarget>The degree of hotness or coldness of a body or environment (corresponding to its molecular activity).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000217"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000729">
+    <skos:definition>Total number of recruits of age class 4.3.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 4.3 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:54:15Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000668"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000175">
+    <skos:relatedMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000172"/>
+    <skos:definition>A regulatory category of Alaskan fishery which is legally defined as, "the taking, fishing for, or possession of finfish, shellfish, or other fishery resources, by Alaska residents for personal use and not for sale or barter, with gill or dip net, seine, fish wheel, long line, or other means defined by the Board of Fisheries." Personal use fisheries may exist only in "nonsubsistence areas" as determined by the state of Alaska (AS 16.05.258(c)).</skos:definition>
+    <rdfs:label xml:lang="en">Personal use fishery</rdfs:label>
+    <dc:description>Personal use fishing is open to Alaskan residents only, and you must have a valid resident Sport Fishing License to participate in personal use fisheries.
+
+The bag, possession, and gear limits in personal use fisheries MAY NOT be added to the bag, possession, and gear limits under sport or subsistence regulations.
+
+It is unlawful to buy, sell, trade or barter personal use finfish, shellfish, aquatic plants, or their parts.
+
+Many, but not all, personal use fisheries require a permit issued by the Department of Fish and Game. Personal use fisheries have many different regulations for bag limits, allowable gear, and time and area restrictions. Some personal use fisheries are managed in-season by emergency order, so regulations can change at any time.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-02T22:17:54Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000807"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002772">
+    <rdfs:label xml:lang="en">river or stream name</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-04-25T22:17:53Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002768"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000705">
+    <skos:definition>Total number of recruits of age class 0.6.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 0.6 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:48:30Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000664"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A116">
+    <rdfs:comment>This URI does not appear to dereference to the term. Including this URL, https://bioportal.bioontology.org/ontologies/NCIT?p=classes&amp;conceptid=http%3A%2F%2Fncicb.nci.nih.gov%2Fxml%2Fowl%2FEVS%2FThesaurus.owl%23C25150, to ensure findability.</rdfs:comment>
+    <owl:annotatedTarget>http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C25150</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#closeMatch"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000184"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A74">
+    <rdf:rest rdf:nodeID="A117"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000677"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A118">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Salmon_escapement, accessed 2021-04-26
+https://www.wikidata.org/wiki/Q23582242, accessed 2021-04-26</j.4:hasDbXref>
+    <owl:annotatedTarget>The number of salmon which do not get caught by commercial or recreational fisheries and return to their freshwater spawning habitat.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000479"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000173">
+    <skos:definition>The artificial breeding, hatching, and rearing through the early life stages of animals -- finfish and shellfish in particular. Hatcheries produce larval and juvenile fish, shellfish, and crustaceans, primarily to support the aquaculture industry where they are transferred to on-growing systems, such as fish farms, to reach harvest size.</skos:definition>
+    <rdfs:label xml:lang="en">Hatchery</rdfs:label>
+    <rdfs:comment>Oftentimes, hatchery-reared salmon will have their adipose fins removed (i.e. clipped) to mark that they come from a hatchery (versus a wild stock).</rdfs:comment>
+    <dc:description>The Alaska hatchery program was designed to increase salmon abundance and enhace fisheries, while protecting wild stocks. The program was built in response to depressed commercial fisheries, to meet the needs of the people of the state.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-02T20:00:45Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000639"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2002/07/owl#equivalentClass">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A119">
+    <dc:source>http://calfish.ucdavis.edu/species/?uid=39&amp;ds=698</dc:source>
+    <owl:annotatedTarget>Sea-running, i.e. anadromous individuals of Rainbow Trout, are called Steelhead.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000580"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A120">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>This identification type will last the entire life of the fish and is primarily used for group marking, though the fish must be euthanized for reading. Altering the appearance of otoliths may be achieved in a variety of ways, including (a) exposing a fish to variations in water temperature of at least 3 degrees Celsius a number of times to create darker and lighter bands in the otoliths, (b) bathing the fish or eggs in an aqueous solution with fluorescent dye, which is absorbed into the otoliths, or (c)  bathing the fish in strontium chloride solution or feeding the fish food that contains the metallic substance strontium.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000553"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A121">
+    <j.4:hasDbXref>https://www.adfg.alaska.gov/fedaidpdfs/FRED.132.pdf, accessed 2021-04-15</j.4:hasDbXref>
+    <owl:annotatedTarget>A method which is used to approximate the age of a fish and which generally involves extracting the otoliths from a fish, then counting the number of annuli (i.e. year marks).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000232"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A122">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>This type of identification is usually visible for one year on salmon, is primarily used for group marking, and is suitable for fish that weigh at least 20g. An ink solution (often Alcian blue dissolved in distilled water) is typically injected under the skin using a syringe with a cannula. Marking a fish using the "square dot system" with up to 3x3 dots is common. Unlike VIE, tattoos do not require transparent skin to be visible. However, in salmon, the tattoo should be placed in areas in front of the pelvic fins, under the pectoral fins and/or behind the anal fins to enable reading during spawning, when the fish's natural pigmentation may cover up the tattoo.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000555"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000619">
+    <rdfs:label xml:lang="en">reproductiveStrategyOf</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-01T20:30:32Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:domain rdf:resource="http://purl.dataone.org/odo/SALMON_00000611"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000728">
+    <skos:definition>Total number of recruits of age class 4.2.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 4.2 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:54:08Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000668"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000704">
+    <skos:definition>Total number of recruits of age class 1.9.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 1.9 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:48:13Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000665"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000198">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/ENVO_00000033</skos:exactMatch>
+    <skos:definition>A body of water, usually of smaller size than a lake.</skos:definition>
+    <rdfs:label xml:lang="en">Pond</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-07T18:47:40Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000197"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A123">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>A mark or tag which is placed beneath the skin of a fish.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000559"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A124">
+    <dc:source>http://purl.dataone.org/odo/ECSO_00001231</dc:source>
+    <owl:annotatedTarget>Objective comparative measure of hot or cold of water in a lake.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000414"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A125">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:nodeID="A126"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000196">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/ENVO_01000618</skos:exactMatch>
+    <skos:definition>A water body in which the accumulated water, in its totality, is flowing.</skos:definition>
+    <rdfs:label xml:lang="en">Lotic water body</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-07T18:44:17Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000125"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000172">
+    <skos:definition>A fishery in which fishes or other seafood are harvested for noncommercial, customary and traditional uses. These uses include direct personal or family consumption as food, shelter, fuel, clothing, tools, or transportation, for the making and selling of handicraft articles out of nonedible by-products of fish and wildlife resources taken for personal or family consumption, and for the customary trade, barter, or sharing for personal or family consumption.</skos:definition>
+    <skos:altLabel>artisinal fishery
+traditional fishery</skos:altLabel>
+    <rdfs:label xml:lang="en">Subsistence fishery</rdfs:label>
+    <dc:description>In Alaska, subsistence fisheries may not operate in "nonsubsistence areas" as designated by the state (AS 16.05.258(c)).</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-02T20:00:36Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000137"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002556">
+    <rdfs:label xml:lang="en">signal quality</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-26T17:39:32Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00001719"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A127">
+    <owl:members rdf:nodeID="A31"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000509">
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000461"/>
+    <rdfs:label xml:lang="en">Oncorhynchus keta</rdfs:label>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000587"/>
+    <j.2:nameAccordingTo rdf:resource="http://purl.dataone.org/odo/SALMON_00000475"/>
+    <owl:sameAs rdf:resource="http://purl.dataone.org/odo/SALMON_00000801"/>
+    <j.1:SALMON_00000618 rdf:resource="http://purl.dataone.org/odo/SALMON_00000613"/>
+    <j.2:vernacularName rdf:resource="http://purl.dataone.org/odo/SALMON_00000801"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-30T17:44:51Z</dc:date>
+    <j.1:SALMON_00000617 rdf:resource="http://purl.dataone.org/odo/SALMON_00000615"/>
+    <j.2:vernacularName rdf:resource="http://purl.dataone.org/odo/SALMON_00000514"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000618">
+    <rdfs:label xml:lang="en">hasReproductiveStrategy</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-01T20:27:15Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:range rdf:resource="http://purl.dataone.org/odo/SALMON_00000611"/>
+    <owl:inverseOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000619"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000727">
+    <skos:definition>Total number of recruits of age class 4.1.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 4.1 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:54:02Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000668"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000197">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/ENVO_01000617</skos:exactMatch>
+    <skos:definition>A water body in which the accumulated water, in its totality, has very little to no directed flow.</skos:definition>
+    <rdfs:label xml:lang="en">Lentic water body</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-07T18:47:13Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000125"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000703">
+    <skos:definition>Total number of recruits of age class 1.8.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 1.8 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:48:00Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000665"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000195">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/ENVO_00000495</skos:exactMatch>
+    <skos:definition>A stream or river which flows into another river (a parent river) or body of water but which may not flow directly into the sea.</skos:definition>
+    <skos:altLabel>affluent</skos:altLabel>
+    <rdfs:label xml:lang="en">Tributary</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-07T18:40:15Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000194"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A128">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>The alteration of a physical bodily feature of a fish, either internally or externally, for identification purposes.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000557"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A129">
+    <rdfs:comment>"POHL" is an acronym used by Alaska Department of Fish &amp; Game (ADF&amp;G)</rdfs:comment>
+    <owl:annotatedTarget>POHL</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000130"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A130">
+    <j.4:hasDbXref>https://fishbio.com/field-notes/fish-monitoring/pit-tag-the-full-story, accessed 05May2021
+https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 05May2021</j.4:hasDbXref>
+    <owl:annotatedTarget>A small, passive (i.e. does not actively send out a signal and does not require a battery) radio transponder tag which, when in range, is activated by a signal emitted from a tag reader. The tag then emits a unique identification code back to the reader.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000551"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A131">
+    <dc:source>https://en.wikipedia.org/wiki/Oxygen_saturation, accessed 22April2021
+https://www.wikidata.org/wiki/Q6294669, accessed 22April2021</dc:source>
+    <owl:annotatedTarget>Dissolved oxygen saturation can be measured with a dissolved oxygen probe such as an oxygen sensor or an optode in liquid media, usually water. The standard unit of oxygen saturation is percent (%).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000425"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000508">
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000587"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-30T17:44:44Z</dc:date>
+    <j.1:SALMON_00000618 rdf:resource="http://purl.dataone.org/odo/SALMON_00000613"/>
+    <rdfs:label xml:lang="en">Oncorhynchus gorbuscha</rdfs:label>
+    <j.2:vernacularName rdf:resource="http://purl.dataone.org/odo/SALMON_00000516"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <j.1:SALMON_00000617 rdf:resource="http://purl.dataone.org/odo/SALMON_00000615"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000460"/>
+    <j.2:nameAccordingTo rdf:resource="http://purl.dataone.org/odo/SALMON_00000475"/>
+    <owl:sameAs rdf:resource="http://purl.dataone.org/odo/SALMON_00000800"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A132">
+    <dc:source>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</dc:source>
+    <owl:annotatedTarget>The appearance of the otoliths (located in the inner ear of the fish) are changed.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000553"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000617">
+    <rdfs:label xml:lang="en">hasMigratoryPattern</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-01T20:26:57Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:range rdf:resource="http://purl.dataone.org/odo/SALMON_00000614"/>
+    <owl:inverseOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000620"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000726">
+    <skos:definition>Total number of recruits of age class 3.9.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 3.9 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:52:44Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000667"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000702">
+    <skos:definition>Total number of recruits of age class 1.7.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 1.7 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:47:48Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000665"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A133">
+    <dc:source>https://www.merriam-webster.com/dictionary/grilse</dc:source>
+    <owl:annotatedTarget>a young Atlantic salmon returning to its native river to spawn for the first time after one winter at sea</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000806"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000170">
+    <skos:definition>A fishery in which fishes and other seafood are harvested for pleasure or competition.</skos:definition>
+    <skos:altLabel>sport fishery</skos:altLabel>
+    <rdfs:label xml:lang="en">Recreational (sport) fishery</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-02T20:00:25Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000137"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000194">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/ENVO_00000023</skos:exactMatch>
+    <skos:definition>A watercourse which is linear and flows across the solid portion of a planetary surface.</skos:definition>
+    <rdfs:label xml:lang="en">Stream</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-07T18:40:11Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000230"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000507">
+    <skos:definition>Young fish, mostly similar in form to adult but not yet sexually mature (Hubbs, 1943). In some cases refers to a stage unlike the adult in appearance.</skos:definition>
+    <rdfs:label xml:lang="en">Juvenile</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-29T19:11:32Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000401"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A134">
+    <j.4:hasDbXref>https://www.adfg.alaska.gov/index.cfm?adfg=wildlifenews.view_article&amp;articles_id=693, accessed 2021-06-15</j.4:hasDbXref>
+    <owl:annotatedTarget>Oftentimes, hatchery-reared salmon will have their adipose fins removed (i.e. clipped) to mark that they come from a hatchery (versus a wild stock).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000173"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000749">
+    <skos:definition>Total number of recruits of age class 6.5.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 6.5 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:58:05Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000670"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000616">
+    <skos:definition>A classification of fishes which spawn in marine habitats, migrate to freshwater areas to forage and mature, then return to marine habitats to spawn.</skos:definition>
+    <rdfs:label xml:lang="en">Catadromous</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-01T20:11:04Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000614"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A135">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Gigging, accessed 2021-04-01
+https://www.wikidata.org/wiki/Q4412590, accessed 2021-04-01</j.4:hasDbXref>
+    <owl:annotatedTarget>A multi-pronged spear, typically ranging in length from 8 to 14 feet, which is used to spear (or "gig") fishes for harvest.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000156"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000725">
+    <skos:definition>Total number of recruits of age class 3.8.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 3.8 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:52:37Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000667"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000701">
+    <skos:definition>Total number of recruits of age class 1.6.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 1.6 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:47:36Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000665"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000810">
+    <rdfs:label xml:lang="en">Artisanal fishery</rdfs:label>
+    <dc:source>http://www.oceansatlas.org/subtopic/en/c/1303/</dc:source>
+    <dc:description>Typically traditional fisheries involving fishing households (as opposed to commercial companies), using relatively small amount of capital, relatively small fishing vessels, making short fishing trips, close to shore, mainly for local consumption. In practice, definition varies between countries, e.g. from hand-collection on the beach or a one-person canoe in poor developing countries, to more than 20 m. trawlers, seiners, or long-liners over 20m in developed countries. Artisanal fisheries can be subsistence or commercial fisheries, providing for local consumption or export. Sometimes referred to as small-scale fisheries In general, though by no means always, using relatively low level technology. Artisanal and industrial fisheries frequently target the same resources that may give rise to conflict.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-22T05:58:02Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000137"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A136">
+    <rdfs:comment>Indigenous names for salmon can be found by exploring each SASAP region's page on the State of Alaska's Salmon and People website (for example, see the Arctic Region here: https://alaskasalmonandpeople.org/region/arctic/)</rdfs:comment>
+    <dc:source>https://alaskasalmonandpeople.org/regions/, accessed 2021-04-16</dc:source>
+    <owl:annotatedTarget>"Sikayujak" @ipk
+"Ggaal" [Denaakk'e, Koyukon Athabaskan]
+"Gath" [Benhti Kenaga, Lower Tanana]
+"Luk Choo" @gwi
+"Kiagtaq" @ypk
+"Taryaqvak" @ypk
+"Aciirturtet" @ypk
+"sumgax̂" @ale [Unangam tunuu variant]
+"chaguchax̂" @ale [Unangam tunuu variant]
+"chavichax̂" @ale [Unangam tunuu variant]
+"Aamasuuk" [Alutiiq/Sugpiaq]
+"Liliksak" [Alutiiq/Sugpiaq]
+"Luk'ece'e"  [Ahtna]
+"Kentsinai'i" [Ahtna]
+"luq'aka'a" [Kenai Dena'ina]
+"nudlaghi" [Kenai Dena'ina]
+"te'ya'lee" @eya
+"Yee" @tsi @tli
+"t'á" @tsi @tli</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000239"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A137">
+    <owl:someValuesFrom rdf:resource="http://purl.dataone.org/odo/SALMON_00000829"/>
+    <owl:onProperty rdf:resource="http://purl.dataone.org/odo/SALMON_00000828"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A138">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>A small, electronic, sound-emitting device which is placed inside a fish and collects information on that fish's physiology and/or movement patterns.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000534"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002048">
+    <skos:altLabel>hour of day</skos:altLabel>
+    <rdfs:label xml:lang="en">hour of measurement time</rdfs:label>
+    <j.4:hasExactSynonym>hour of day</j.4:hasExactSynonym>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-14T22:40:52Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002040"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A139">
+    <dc:source>https://www.adfg.alaska.gov/static/license/fishing/pdfs/coar_fish_codes.pdf, accessed 04May2021</dc:source>
+    <owl:annotatedTarget>ADF&amp;G salmon species codes:
+
+410 salmon, chinook
+420 salmon, sockeye
+430 salmon, coho
+440 salmon, pink
+450 salmon, chum</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000525"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A140">
+    <dc:source>https://en.wikipedia.org/wiki/Seawater
+https://www.wikidata.org/wiki/Q184395</dc:source>
+    <owl:annotatedTarget>On average, seawater in the world's oceans has a salinity of about 3.5% (35 g/l, 35 ppt, 599 mM).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000203"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A141">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>Fishing gear which is used to collect fish and can be operated by hand by one or few people. Hand collection methods may also include the collection of fish without the aid of any gear (i.e. gathering live fish or carcasses using only one's hands).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000164"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A142">
+    <dc:source>http://purl.dataone.org/odo/ECSO_00001523</dc:source>
+    <owl:annotatedTarget>An aquatic temperature which inheres in water close to the surface of an ocean or sea. The exact meaning of surface varies according to the measurement method used, but it is between 1 millimetre (0.04 in) and 20 metres (70 ft) below the sea surface.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000415"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000683">
+    <rdfs:label xml:lang="en">Whole fish weight</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-23T18:46:24Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000658"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A143">
+    <dc:source>https://en.wikipedia.org/wiki/Fishing_weir, accessed 2021-04-01
+https://www.wikidata.org/wiki/Q1417573, accessed 2021-04-01</dc:source>
+    <owl:annotatedTarget>An obstruction placed in tidal waters, or wholly or partially across a river, to direct the passage of, or trap fish.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000148"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A144">
+    <dc:source>https://www.adfg.alaska.gov/index.cfm?adfg=fishingaquaticfarming.programinfo, accessed 2021-04-02</dc:source>
+    <owl:annotatedTarget>In Alaska, the aquaculture industry primarily produces Pacific oysters, littleneck clams, and mussels for commercial food production.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000176"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000550">
+    <skos:definition>A system which uses electromagnetic fields to automatically identify and track tags attached to objects.</skos:definition>
+    <skos:altLabel>Radio Frequency Identification</skos:altLabel>
+    <rdfs:label xml:lang="en">RFID</rdfs:label>
+    <dc:description>An RFID system consists of a tiny transponder, a radio receiver, and an transmitter. When triggered by an electromagnetic interrogation pulse from a nearby FRID reader device, the tag transmits digital data, usually an identifying inventory number, back to the reader.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:47:51Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000545"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000223">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/ENVO_00000137</skos:exactMatch>
+    <skos:definition>An opening of the sea into the land.</skos:definition>
+    <rdfs:label xml:lang="en">Coastal inlet</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-15T18:39:14Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000222"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000598">
+    <j.2:nameAccordingTo rdf:resource="http://purl.dataone.org/odo/SALMON_00000595"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-27T19:40:11Z</dc:date>
+    <rdfs:comment>Some populations of the coastal cutthroat trout (O. c. clarkii) are semi-anadromous. (source: https://en.wikipedia.org/wiki/Cutthroat_trout)</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:label xml:lang="en">Oncorhynchus clarkii</rdfs:label>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000594"/>
+    <j.1:SALMON_00000618 rdf:resource="http://purl.dataone.org/odo/SALMON_00000612"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000587"/>
+    <j.2:vernacularName rdf:resource="http://purl.dataone.org/odo/SALMON_00000603"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000489">
+    <rdfs:label xml:lang="en">Sexual dimorphic characteristic</rdfs:label>
+    <rdfs:comment>A method that uses the presence or other features of a  trait ("characteristic") of an organism to differentiate or assign gender</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-28T00:02:33Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000485"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A145">
+    <rdfs:comment>https://doi.org/10.1577/M02-143, accessed 2021-05-05</rdfs:comment>
+    <owl:annotatedTarget>Though not well studied, this type of identification may last up to 3 years post-immersion, and is used for group marking.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000537"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002132">
+    <rdfs:label xml:lang="en">longitude coordinate</rdfs:label>
+    <dc:description>Longitude (/ˈlɒndʒɪtjuːd/, AU and UK also /ˈlɒŋɡɪ-/)[1][2] is a geographic coordinate that specifies the east–west position of a point on the Earth's surface, or the surface of a celestial body. It is an angular measurement, usually expressed in degrees and denoted by the Greek letter lambda (λ). Meridians (lines running from pole to pole) connect points with the same longitude. The prime meridian, which passes near the Royal Observatory, Greenwich, England, is defined as 0° longitude by convention. Positive longitudes are east of the prime meridian, and negative ones are west.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-17T18:58:37Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002269"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002047">
+    <rdfs:label xml:lang="en">month of year</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-14T22:26:35Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002043"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#relatedMatch">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A146">
+    <dc:source rdf:resource="http://purl.obolibrary.org/obo/PCO_0000023"/>
+    <owl:annotatedTarget>A quality of an ecological community that reflects how close in abundance all species in a community are.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000628"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A61">
+    <rdf:rest rdf:nodeID="A6"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000239"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A147">
+    <dc:source>http://www.fao.org/fishery/geartype/202/en, accessed 01April2021</dc:source>
+    <owl:annotatedTarget>A seine net operated from the shore. The gear is composed of a bunt (bag or lose netting) and long wings often lengthened with long ropes for towing the seine to the beach. The headrope with floats is on the surface, the footrope is in permanent contact with the bottom and the seine is therefore a barrier which prevent the fish from escaping from the area enclosed by the net</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000151"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000682">
+    <rdfs:label xml:lang="en">Project name</rdfs:label>
+    <dc:description>The label, acronym, or other preferred way to refer to a Project</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-23T18:22:30Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000222">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/ENVO_00000475</skos:exactMatch>
+    <skos:definition>An opening of the sea into the land, or of a lake into its shore.</skos:definition>
+    <rdfs:label xml:lang="en">Inlet</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-15T18:37:33Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000125"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A148">
+    <dc:source>http://www.fishbase.us/glossary/Glossary.php?q=fry&amp;language=english&amp;sc=is, accessed 2021-04-21</dc:source>
+    <owl:annotatedTarget>A young fish at the post-larval stage. May include all fish stages from hatching to fingerling. An advanced fry is any young fish from the start of exogenous feeding after the yolk is absorbed while a sac fry is from hatching to yolk sac absorption. In Salmonidae the stage from end of dependence on the yolk sac as the primary source of nutrition to dispersal from the redd.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000405"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000464">
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-26T20:19:15Z</dc:date>
+    <skos:definition>The class which contains all instances of Oncorhynchus tshawytscha.</skos:definition>
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000239"/>
+    <dc:description>Oncorhynchus tshawytscha (i.e. Chinook salmon) is the largest of the five species of Pacific salmon.
+
+Physical Description: The Chinook is blue-green, red, or purple on the back and top of the head, with silvery sides and white ventral surfaces. It has black spots on its tail and the upper half of its body. Although spots are seen on the tail in pink salmon, and silver on the tail in coho and chum salmon, Chinook are unique among the Pacific salmon in combining black spots and silver on the tail. Another distinctive feature is a black gum line that is present in both salt and freshwater. Adult fish range in size from 24 to 36 in (61 to 91 cm), but may be up to 58 in (150 cm) in length; they average 10 to 50 lb (4.5 to 22.7 kg), but may reach 130 lb (59 kg). The meat can be either pink or white in color, depending on what the salmon have been feeding on.
+
+Range: Chinook are anadromous fish native to the North Pacific Ocean and the river systems of western North America, ranging from California to Alaska, as well as Asian rivers ranging from northern Japan to the Palyavaam River in the Arctic northeast Siberia. They have been introduced to other parts of the world, including New Zealand, thriving in Lake Michigan Great Lakes of North America and Michigan's western rivers, and Patagonia.</dc:description>
+    <rdfs:label xml:lang="en">Oncorhynchus tshawytscha</rdfs:label>
+    <j.4:hasDbXref>NCBI:txid74940
+ITIS: 161980 (https://itis.gov/servlet/SingleRpt/SingleRpt?search_topic=TSN&amp;search_value=161980#null)
+GBIF: 5204024 (https://www.gbif.org/species/5204024)
+EOL: 46563139 (https://eol.org/pages/46563139, currently produces and error 505)
+COL: 49JFR (https://www.catalogueoflife.org/data/taxon/49JFR)
+Wikidata: Q833503 (https://www.wikidata.org/wiki/Q833503)</j.4:hasDbXref>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000587"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <skos:altLabel>O. tshawytscha</skos:altLabel>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A149">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Commercial_fishing, accessed  2021-04-02
+https://www.wikidata.org/wiki/Q11202642, accessed 2021-04-02</j.4:hasDbXref>
+    <owl:annotatedTarget>A fishery in which fishes and other seafood are harvested for commercial profit, mostly from wild fisheries.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000169"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000137">
+    <rdfs:label xml:lang="en">Fishery type</rdfs:label>
+    <dc:description>The Food and Agriculture Organization of the United Nations (FAO) defines a fishery as "...an activity leading to harvesting of fish. It may involve capture of wild fish or raising of fish through aquaculture."</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T17:33:14Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000488">
+    <rdfs:label xml:lang="en">Hermaphrodite</rdfs:label>
+    <rdfs:comment>Used to designate that some individual or individuals in a group of organisms possessed functional qualities of more than one gender, simultaneously or sequentially.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T23:59:24Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000216"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A150">
+    <dc:source>http://www.fishbase.us/glossary/Glossary.php?q=juvenile&amp;language=english&amp;sc=is, accessed 2021-06-15</dc:source>
+    <owl:annotatedTarget>Young fish, mostly similar in form to adult but not yet sexually mature (Hubbs, 1943). In some cases refers to a stage unlike the adult in appearance.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000507"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000680">
+    <skos:definition>A numeric value assigned to a scale gum card.</skos:definition>
+    <rdfs:label xml:lang="en">Gum card number</rdfs:label>
+    <dc:description>Gum cards are used to mount and label the identity of sampled fish scales.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-23T17:34:31Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000528"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A151">
+    <dc:source>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</dc:source>
+    <owl:annotatedTarget>A barbed plastic tag which is inserted under the dorsal fin of the fish using a cannula.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000549"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/creator">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A152">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>When done correctly, this identification type will remain visible for the entire lifetime of the fish and can be used for group or individual marking. Neon or fluorescent colors are often used, and best placement is in light areas and fin rays, though even semi-transparent and transparent tissue may be suitable for easy visual reading.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000554"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000681">
+    <skos:definition>A numeric or alphanumeric code which represents potential sources of error in determining the age of a fish specimen.</skos:definition>
+    <rdfs:label xml:lang="en">Age error code</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-23T17:53:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000672"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000572">
+    <skos:definition>An identifier which represents a region or location in and is used in place of the full name.</skos:definition>
+    <rdfs:label xml:lang="en">Region or location code</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-12T17:37:57Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000672"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000463">
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000587"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-26T20:19:04Z</dc:date>
+    <skos:definition>The class which contains all instances of Oncorhynchus nerka.</skos:definition>
+    <dc:description>Oncorhynchus nerka (i.e. sockeye salmon) is one of the five species of Pacific salmon.
+
+Physical Description: The sockeye salmon is sometimes called red or blueback salmon, due to its color. Sockeye are blue tinged with silver in color while living in the ocean. When they return to spawning grounds, their bodies become red and their heads turn green. Sockeye can be anywhere from 60 to 84 cm (2 ft 0 in–2 ft 9 in) in length and weigh from 2.3 to 7 kg (5–15 lb). Two distinguishing features are their long, serrated gill rakers that range from 30 to 40 in number, and their lack of a spot on their tail or back.
+
+Range: Sockeye salmon range as far south as the Columbia River in the eastern Pacific (although individuals have been spotted as far south as the 10 Mile River on the Mendocino Coast of California) and in northern Hokkaidō Island in Japan in the western Pacific. They range as far north as the Bathurst Inlet in the Canadian Arctic in the east and the Anadyr River in Siberia in the west. The farthest inland sockeye salmon travel is to Redfish Lake, Idaho, over 1,400 km (900 mi) from the ocean and 2,000 m (6,500 ft) in elevation. In the United States, populations of sockeye salmon have been extirpated from Idaho and Oregon.</dc:description>
+    <j.4:hasDbXref>NCBI:txid8023
+ITIS: 161979 (https://itis.gov/servlet/SingleRpt/SingleRpt?search_topic=TSN&amp;search_value=161979#null)
+GBIF: 5204039 (https://www.gbif.org/species/5204039)
+EOL: 46563140 (https://eol.org/pages/46563140, currently produces an error 505)
+COL: 49JFH (https://www.catalogueoflife.org/data/taxon/49JFH)
+Wikidata: Q44064 (https://www.wikidata.org/wiki/Q44064)</j.4:hasDbXref>
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000242"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:label xml:lang="en">Oncorhynchus nerka</rdfs:label>
+    <skos:altLabel>O. nerka</skos:altLabel>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000596">
+    <rdfs:label xml:lang="en">hasADF&amp;GCode</rdfs:label>
+    <dc:description>Alaska Department of Fish and Game (ADF&amp;G) uses a list of numeric codes to describe (a) commercially-harvested aquatic species, (b) gear used for harvest, (c) method of catch processing, and (d) delivery form and product type.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-27T18:00:35Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+    <rdfs:domain rdf:nodeID="A153"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000487">
+    <rdfs:label xml:lang="en">Genetic sexing</rdfs:label>
+    <rdfs:comment>Determination of fish gender based on genetic evidence rather than morphological evidence alone
+
+This may be a good resource: https://www.fws.gov/r7/fisheries/genetics/pdf/09_rf_2004_OlsenMillerHarperNaglerVanHattenWhittonWenburg_OS.pdf</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T23:57:56Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000186"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A154">
+    <j.4:hasDbXref>https://doi.org/10.1186/2050-3385-1-18, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>A scar made on the dermal tissue using liquid nitrogen.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000538"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#altLabel">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A155">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Alkalinity, accessed 2021-04-22
+https://www.wikidata.org/wiki/Q432016, accessed 2021-04-22</j.4:hasDbXref>
+    <owl:annotatedTarget>A measure of the quantitative capacity of an aqueous solution to neutralize an acid.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000420"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002243">
+    <rdfs:label xml:lang="en">latitude second component</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-28T21:37:49Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002130"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A156">
+    <dc:source>http://calfish.ucdavis.edu/species/?uid=39&amp;ds=698</dc:source>
+    <owl:annotatedTarget>Sea-running, i.e. anadromous individuals of Rainbow Trout are called Steelhead.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000647"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000570">
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-11T17:26:46Z</dc:date>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000591"/>
+    <rdfs:label xml:lang="en">Steelhead trout</rdfs:label>
+    <j.2:scientificName rdf:resource="http://purl.dataone.org/odo/SALMON_00000647"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000570"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000126"/>
+    <skos:altLabel>Oncorhynchus mykiss irideus
+Oncorhynchus m. irideus
+O. m. irideus
+"steelhead" @en</skos:altLabel>
+    <j.1:SALMON_00000596 rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">540</j.1:SALMON_00000596>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A157">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>The total number of recruits which successfully return to spawn in freshwater habitats for a given brood year.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000505"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A158">
+    <rdfs:comment>"hasDbXref' is used here to indicate the equivalence of this Class with its usage in a Darwin Core context</rdfs:comment>
+    <owl:annotatedTarget>http://rs.tdwg.org/dwc/terms/Occurrence</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000827"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000220">
+    <skos:definition>Measurement types which pertain to any product of the condensation of atmospheric water vapor that falls under gravity.</skos:definition>
+    <rdfs:label xml:lang="en">Precipitation measurement type</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-14T22:31:36Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000214"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000571">
+    <rdfs:label xml:lang="en">Pacific salmon</rdfs:label>
+    <dc:description>There are five species of Pacific salmon, which occur in the North Pacific waters of the United States and Canada -- Chinook, Chum, Coho, Pink, and Sockeye. All five species are anadromous, meaning that they spawn in freshwater, migrate to the ocean to forage and mature, and return to freshwater to spawn and begin the cycle again.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-11T17:26:55Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000458"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000462">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-26T20:18:52Z</dc:date>
+    <skos:altLabel>O. kisutch</skos:altLabel>
+    <j.4:hasDbXref>NCBI:txid8019
+ITIS: 161977 (https://www.itis.gov/servlet/SingleRpt/SingleRpt?search_topic=TSN&amp;search_value=161977#null)
+GBIF: 5204034 (https://www.gbif.org/species/5204034)
+EOL: 46563137 (https://eol.org/pages/46563137)
+COL: 49JF8 (https://www.catalogueoflife.org/data/taxon/49JF8)
+Wikidata: Q934874 (https://www.wikidata.org/wiki/Q934874)</j.4:hasDbXref>
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000243"/>
+    <dc:description>Oncorhynchus kisutch (i.e. coho salmon) is one of the five species of Pacific salmon.
+
+Physical Description: During their ocean phase, coho salmon have silver sides and dark-blue backs. During their spawning phase, their jaws and teeth become hooked. After entering fresh water, they develop bright-red sides, bluish-green heads and backs, dark bellies and dark spots on their backs. Sexually maturing fish develop a light-pink or rose shading along the belly, and the males may show a slight arching of the back. Mature adults have a pronounced red skin color with darker backs and average 28 inches (71 cm) and 7 to 11 pounds (3.2 to 5.0 kg), occasionally reaching up to 36 pounds (16 kg). They also develop a large kype (hooked beak) during spawning. Mature females may be darker than males, with both showing a pronounced hook on the nose.
+
+Range: The traditional range of the coho salmon runs along both sides of the North Pacific Ocean, from Hokkaidō, Japan and eastern Russia, around the Bering Sea to mainland Alaska, and south to Monterey Bay, California. Coho salmon have also been introduced in all the Great Lakes, as well as many landlocked reservoirs throughout the United States. A number of specimens, (more than 20), were caught in waters surrounding Denmark and Norway in 2017. Their source is currently unknown, but the salmon species is farmed at several locations in Europe, making it probable that the animal has slipped the net at such a farm.</dc:description>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000587"/>
+    <skos:definition>The class which contains all instances of Oncorhynchus kisutch.</skos:definition>
+    <rdfs:label xml:lang="en">Oncorhynchus kisutch</rdfs:label>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000595">
+    <rdfs:label xml:lang="en">Richardson, 1836</rdfs:label>
+    <rdfs:comment>Sir John Richardson (5 ovember 1787 - 5 June 1865) was a Scottish naval surgeon, naturalist and arctic explorer.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-27T00:09:04Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000495"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000486">
+    <rdfs:label xml:lang="en">Internal sex determination method</rdfs:label>
+    <rdfs:comment>Determination of fish gender based on internal examination, e.g. examination of gonads</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T23:57:03Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000186"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000159">
+    <skos:definition>A type of fishing gear which uses direct current electricity flowing between a submerged cathod and anode to cause galvanotaxis, or an uncontrolled muscular convulsion, which affects the movement of the fish such that it swims towards the anode, where it is then collected.</skos:definition>
+    <rdfs:label xml:lang="en">Electrofishing</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T18:02:48Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000164"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000135">
+    <skos:definition>The measurement from the most anterior tip of the body to the midlateral posterior edge of the hypural plate (in fish with a hypural plate) or to the posterior end of the vertebral column (in fish lacking hypural plates).</skos:definition>
+    <skos:altLabel>SL</skos:altLabel>
+    <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/SALMON_00000637"/>
+    <rdfs:label xml:lang="en">Standard length</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T18:21:24Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000127"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A159">
+    <j.4:hasDbXref>https://spo.nmfs.noaa.gov/sites/default/files/legacy-pdfs/leaflet488.pdf, accessed 2021-04-27</j.4:hasDbXref>
+    <owl:annotatedTarget>The number of annuli on a given otolith.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000483"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002440">
+    <rdfs:label xml:lang="en">cruise name</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-15T23:48:23Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002768"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000460">
+    <rdfs:label xml:lang="en">Oncorhynchus gorbuscha</rdfs:label>
+    <dc:description>Oncorhynchus gorbuscha (i.e. pink salmon) is the smallest and most abundant of the five species of Pacific salmon.
+
+Physical Description: In the ocean, pink salmon are bright silver fish. After returning to their spawning streams, their coloring changes to pale grey on the back with yellowish-white belly (although some turn an overall dull green color). As with all salmon, in addition to the dorsal fin, they also have an adipose fin. The fish is characterized by a white mouth with black gums, no teeth on the tongue, large oval-shaped black spots on the back, a v-shaped tail, and an anal fin with 13-17 soft rays. During their spawning migration, males develop a pronounced humped back, hence their nickname "humpies". Pink salmon average 4.8 pounds (2.2 kg) in weight. The maximum recorded size was 30 inches (76 cm) and 15 pounds (6.8 kg).
+
+Range: The native range of the species is in the Pacific and Arctic coastal waters and rivers, from the Sacramento River in northern California to the Mackenzie River in Canada; and in the west from the Lena River in Siberia to Korea and Honshu in Japan. In North America pink salmon spawn from the Mackenzie River in the Arctic to as far south as tributaries of Puget Sound, Washington, although they were also reported in the San Lorenzo River near Santa Cruz, California in 1915 and the Sacramento River in northern California in the 1950s. In 2013 a new record for the southernmost extent of spawning pink salmon was published for the Salinas River. In the fall of 2017 a dozen pink salmon were counted in Lagunitas Creek about 25 miles (40 km) north of San Francisco, California.</dc:description>
+    <skos:altLabel>O. gorbuscha</skos:altLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-26T20:17:52Z</dc:date>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000587"/>
+    <skos:definition>The class which contains all instances of Oncorhynchus gorbuscha.</skos:definition>
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000241"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.4:hasDbXref>NCBI:txid8017
+ITIS: 161975 (https://www.itis.gov/servlet/SingleRpt/SingleRpt?search_topic=TSN&amp;search_value=161975#null)
+GBIF: 5204037 (https://www.gbif.org/species/5204037)
+EOL: 46563135 (https://eol.org/pages/46563135)
+COL: 74N5S (https://www.catalogueoflife.org/data/taxon/74N5S)
+Wikidata: Q673380 (https://www.wikidata.org/wiki/Q673380)</j.4:hasDbXref>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002137">
+    <rdfs:label xml:lang="en">latitude minute component</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-17T19:36:39Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002130"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A160">
+    <dc:source>https://www.fisheries.noaa.gov/national/bycatch/fishing-gear-gillnets</dc:source>
+    <owl:annotatedTarget>A gillnet which is attached to poles fixed in the substrate or an anchor system to prevent movement of the net.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000147"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A161">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>The removal of a portion or entirety of a fin or the maxilla of a fish, for identification purposes.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000540"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A162">
+    <dc:source>http://www.fishbase.us/glossary/Glossary.php?q=alevin&amp;language=english&amp;sc=is, accessed 2021-04-21</dc:source>
+    <owl:annotatedTarget>Larval salmon that have hatched but have not yet completely absorbed their yolk sacs and usually have not yet emerged from the gravel.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000403"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000461">
+    <skos:definition>The class which contains all instances of Oncorhynchus keta.</skos:definition>
+    <rdfs:subClassOf rdf:nodeID="A109"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <dc:description>Oncorhynchus keta (i.e. chum salmon) is one of the five species of Pacific salmon.
+
+Physical Description: The body of the chum salmon is deeper than most salmonid species. In common with other species found in the Pacific, the anal fin has 12 to 20 rays, compared with a maximum of 12 in European species. Chum have an ocean coloration of silvery blue green with some indistinct spotting in a darker shade, and a rather paler belly. When they move into fresh water the color changes to dark olive green and the belly color deepens. When adults are near spawning, they have purple blotchy streaks near the caudal peduncle, darker towards the tail. Spawning males typically grow an elongated snout or kype, their lower fins become tipped with white and they have enlarged teeth. Some researchers speculate these characteristics are used to compete for mates.
+
+Range: Chum salmon have the largest natural range of any Pacific salmon, and undergo the longest migrations within the genus Oncorhynchus, far up the Yukon River and deep into the Amur River basin in Asia. In lesser numbers they migrate thousands of kilometres up the Mackenzie River. Chum are found around the north Pacific, in the waters of Korea, Japan, and the Okhotsk and Bering seas (Kamchatka, Chukotka, Kuril Islands, Sakhalin, Khabarovsk Krai, Primorsky Krai), British Columbia in Canada, and from Alaska to California in the United States. In the Arctic Ocean they are found in limited numbers from the Laptev Sea to the Beaufort Sea. In North America chum salmon spawn from the Mackenzie River in the Arctic to as far south as Tillamook Bay, Oregon, although they were also reported in the San Lorenzo River near Santa Cruz, California in 1915 and the Sacramento River in northern California in the 1950s. In fall 2017 a half dozen chum salmon were counted in Lagunitas Creek about 25 miles (40 km) north of San Francisco, California.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-26T20:18:47Z</dc:date>
+    <j.4:hasDbXref>NCBI:txid8018
+ITIS: 161976 (https://itis.gov/servlet/SingleRpt/SingleRpt?search_topic=TSN&amp;search_value=161976#null)
+GBIF: 5204014 (https://www.gbif.org/species/5204014)
+EOL: 46563136 (https://eol.org/pages/46563136)
+COL: 49JF6 (https://www.catalogueoflife.org/data/taxon/49JF6)
+Wikidata: Q475211 (https://www.wikidata.org/wiki/Q475211)</j.4:hasDbXref>
+    <skos:altLabel>O. keta</skos:altLabel>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000587"/>
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000240"/>
+    <rdfs:label xml:lang="en">Oncorhynchus keta</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A163">
+    <dc:source>http://www.adfg.alaska.gov/index.cfm%3Fadfg=dollyvarden.main</dc:source>
+    <owl:annotatedTarget>Some Dolly Varden individuals are anadromous</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000600"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000134">
+    <skos:definition>A fish length measurement of the entire length of a fish's body, taken from the most anterior part of the fish to the tip of the longest caudal fin rays.</skos:definition>
+    <skos:altLabel>TL</skos:altLabel>
+    <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/SALMON_00000638"/>
+    <rdfs:label xml:lang="en">Total length</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T18:21:18Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000127"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A54">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:nodeID="A33"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000594">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-27T00:08:33Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000582"/>
+    <skos:definition>The class which contains all instances of Oncorhynchus clarkii.</skos:definition>
+    <dc:description>Oncorhynchus clarkii (i.e. cutthroat trout) is a species of Pacific trout.
+
+Physical Description: Throughout their native and introduced ranges, cutthroat trout vary widely in size, coloration and habitat selection. Their coloration can range from golden to gray to green on the back. Cutthroat trout can generally be distinguished from rainbow trout by the presence of basibranchial teeth at the base of tongue and a maxillary that extends beyond the posterior edge of the eye. Depending on subspecies, strain and habitat, most have distinctive red, pink, or orange linear marks along the underside of their mandibles in the lower folds of the gill plates.
+
+At maturity, different populations and subspecies of cutthroat trout can range from 6 to 40 inches (15 to 102 cm) in length, depending on habitat and food availability. Sea-run forms of coastal cutthroat trout average 2 to 5 pounds (0.9 to 2.3 kg). The length and weights of mature inland forms vary widely depending on their particular environment and availability of food. Stream-resident fish are much smaller, 0.4 to 3.2 ounces (11 to 91 g), while lacustrine populations have attained weights ranging from 12 to 17 lb (5.4 to 7.7 kg) in ideal conditions. The largest cutthroat trout subspecies is the Lahontan cutthroat trout (O. c. henshawi). These fish average 8 to 9 in (20 to 23 cm) in small streams and 8 to 22 in (20 to 56 cm) in larger rivers and lakes. In ideal environments, the Lahontan cutthroat trout attains typical weights of 0.25 to 8 lb (0.11 to 3.63 kg). The world record cutthroat trout is a Lahontan at 39 in (99 cm) and 41 lb (19 kg).
+
+Range: Cutthroat trout are native to western North America and have evolved through geographic isolation into 14 subspecies, each native to a different major drainage basin. Native cutthroat trout species are found along the Pacific Northwest coast from Alaska through British Columbia into northern California, in the Cascade Range, the Great Basin and throughout the Rocky Mountains including southern Alberta. Some coastal populations of the coastal cutthroat trout (O. c. clarkii) are semianadromous, spending a few months in marine environments to feed as adults and returning to fresh water from fall through early spring to feed on insects and spawn. Cutthroat trout have the second-largest historic native range of North American trout; the lake trout (Salvelinus namaycush) having the largest. Ranges of some subspecies, particularly the westslope cutthroat trout (O. c. lewisi), have been reduced to less than 10 percent of their historic range due to habitat loss and introduction of non-native species.
+
+Although members of Oncorhynchus, the Pacific trout/salmon species, three subspecies—the westslope (O. c. lewisi), the greenback (O. c. stomias) and Yellowstone cutthroat trout (O. c. bouvierii)—evolved populations east of the Continental Divide in the upper Missouri River basin, upper Arkansas and Platte River basins and upper Yellowstone River basin, each which drain into the Atlantic basin via the Mississippi River. Scientists believe that the climatic and geologic conditions 3-5 million years ago allowed cutthroat trout from the Snake River to migrate over the divide into the Yellowstone plateau via Two Ocean Pass. There is also evidence that Yellowstone Lake once drained south into the Snake River drainage. Evidence suggests that the westslope cutthroat trout was able to establish populations east of the divide via Summit Lake at Marias Pass which at one time connected the Flathead River drainage with the upper Missouri River drainage. Scientists speculate that there are several mountain passes associated with the headwaters of the Colorado River drainage and Arkansas/Platte River drainages that would have allowed migration of cutthroat trout east of the divide.
+
+Cutthroat trout have been introduced into non-native waters outside their historic native range, but not to the extent of the rainbow trout (O. mykiss). Within the native range of the Yellowstone cutthroat trout, U.S. Fisheries Bureau and National Park Service authorities introduced Yellowstone cutthroat trout into many fishless lakes in Yellowstone National Park. Cutthroat trout were introduced into Lake Michigan tributaries in the 1890s and sporadically in the early 20th century, but never established wild populations. A population of Yellowstone cutthroat trout purportedly has been established in Lake Huron. Although cutthroat trout are not native to Arizona, they are routinely introduced by the Arizona Game and Fish Department into high mountain lakes in the White Mountains in the northeastern region of that state.</dc:description>
+    <j.4:hasDbXref>NCBI:txid30962
+ITIS: 161983 (https://www.itis.gov/servlet/SingleRpt/SingleRpt?search_topic=TSN&amp;search_value=161983#null)
+GBIF: 5711980 (https://www.gbif.org/species/5711980)
+EOL: 212910 (https://eol.org/pages/212910)
+COL: 6SN65 (https://www.catalogueoflife.org/data/taxon/6SN65)
+Wikidata: Q2717060 (https://www.wikidata.org/wiki/Q2717060)</j.4:hasDbXref>
+    <skos:altLabel>O. clarkii</skos:altLabel>
+    <rdfs:label xml:lang="en">Oncorhynchus clarkii</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000587"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000485">
+    <rdfs:label xml:lang="en">External sex determination method</rdfs:label>
+    <rdfs:comment>Sex determined on basis of organism's external morphology</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T23:56:52Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000186"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A164">
+    <j.4:hasDbXref>https://www.adfg.alaska.gov/static/license/fishing/pdfs/coar_fish_codes.pdf, accessed 04May2021</j.4:hasDbXref>
+    <owl:annotatedTarget>The Alaska Department of Fish and Game defines unique three-digit "Codes for the Commercial Operator's Annual Report" which represent each of the commercially harvested aquatic species.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000525"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000243">
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000462"/>
+    <skos:altLabel>Oncorhynchus kisutch
+O. kisutch
+"silver salmon" @en
+"silvers" @en</skos:altLabel>
+    <skos:altLabel>"Saanlaaghe" [Denaakk'e, Koyukon Athabaskan]
+"Khwyhts'en'" [Benhti Kenaga, Lower Tanana]
+"Shii" @gwi
+"Caayuryaq" @ypk
+"Qakiiyaq" @ypk
+"Qavlunaq" @ypk
+"Uqurliq" @ypk
+"Qakiidax̂: @ale [Unangam tunuu variant]
+"Qakiiyaq" [Alutiiq/Sugpiaq]
+"ta'ay" @eyk
+"ÜÜx" @tsi @tli
+"L'ook" @tsi @tli</skos:altLabel>
+    <rdfs:label xml:lang="en">Coho salmon</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-16T18:11:22Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A165">
+    <dc:source>https://en.wikipedia.org/wiki/Standard_weight_in_fish, accessed 2021-06-16
+https://www.wikidata.org/wiki/Q7598325, accessed 2021-06-16</dc:source>
+    <owl:annotatedTarget>The typical or expected weight at a given total length for a specific species of fish. Most standard weight equations are for freshwater fish species.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000661"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A166">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>A metal plate with a unique identifying code, which is attached to a fish below the dorsal fin via two stainless steel wires.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000548"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000158">
+    <skos:definition>A large wall of netting deployed around an entire area or school of fish. The seine has floats along the top line with a lead line threaded through rings along the bottom. Once a school of fish is located, a skiff encircles the school with the net. The lead line is then pulled in, "pursing" the net closed on the bottom, preventing fish from escaping by swimming downward. The catch is harvested by either hauling the net aboard or bringing it alongside the vessel.</skos:definition>
+    <skos:closeMatch rdf:resource="http://vocab.nerc.ac.uk/collection/M13/current/015/"/>
+    <rdfs:label xml:lang="en">Purse seine</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T18:02:44Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000162"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A167">
+    <dc:source>https://en.wikipedia.org/wiki/Oxygen_saturation, accessed 22April2021
+https://www.wikidata.org/wiki/Q6294669, accessed 22April2021</dc:source>
+    <owl:annotatedTarget>A relative measure of the concentration of oxygen that is dissolved or carried in a given medium as a proportion of the maximal concentration that can be dissolved in that medium.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000425"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000592">
+    <rdfs:label xml:lang="en">Salvelinus spp.</rdfs:label>
+    <dc:description>Salvelinus is a genus of salmonid fish often called char or charr; some species are called "trout". Salvelinus is a member of the subfamily Salmoninae within the family Salmonidae.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-27T00:07:24Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000458"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002269">
+    <rdfs:label xml:lang="en">latitude and longitude coordinates</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-29T00:50:47Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002114"/>
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000830"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A168">
+    <j.4:hasDbXref>http://courses.washington.edu/fish450/Lecture%20PDFs/Salmon_age_and_size_at_maturity.pdf, accessed 2021-04-06</j.4:hasDbXref>
+    <owl:annotatedTarget>The sum of freshwater and marine annuli plus one to account for time spent in the gravel before hatching.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000187"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A169">
+    <dc:source>https://arcos.disl.org/main/whatisDO#:~:text=Dissolved%20Oxygen%20is%20the%20amount,can%20affect%20dissolved%20oxygen%20levels, accessed 2021-04-22</dc:source>
+    <owl:annotatedTarget>The amount of gaseous oxygen (O2) dissolved in water.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000424"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A170">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>There are four main methods for collecting tissue samples for DNA sequencing: (1) collecting a fin sample, (2) swabbing the mucus layer of the fish, (3) collecting a scale sample, and (4) blood sampling. Genetic identification can provide better answers to some questions that are also answered through typical fish marking and tagging, such as effective population size, whether populations differ and the degree of inbreeding. However, genetic identification cannot answer questions about, for example migration patterns, movement in the water and growth.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000533"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A171">
+    <dc:source>https://www.fws.gov/guidance/sites/default/files/documents/Calcein_%28SE%20Mark%29_Study_Protocol.pdf, accessed 2021-05-05</dc:source>
+    <owl:annotatedTarget>SE-MARK</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000537"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000242">
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000463"/>
+    <skos:altLabel>Oncorhynchus nerka
+O. nerka
+"red salmon" @en
+"kokanee" @en
+"kokanee salmon" @en
+"blueback salmon" @en
+"blue-back" @en
+"Fraser River salmon" @en
+"redfish" @en
+"sock-eye salmon" @en
+"sox" @en</skos:altLabel>
+    <skos:altLabel>"Cayak" @ypk
+"Sayak" @ypk
+"Niklliq" [Alutiiq/Sugpiaq]
+"Nulaeggi" [Ahtna]
+"Sesluugge"' [Ahtna]
+"Natael luugge'" [Ahtna]
+"k'q'uya" [Kenai Dena'ina]
+"tahi'id" @eyk
+"cha'ch" @eyk
+"Misoo" @tsi @tli
+"g̲aat" @tsi @tli</skos:altLabel>
+    <rdfs:label xml:lang="en">Sockeye salmon</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-16T18:11:02Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000593">
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000569"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000592"/>
+    <dc:description>Salvelinus malma (i.e. the dolly varden trout) is a species of Pacific trout, belonging to the genus Salvelinus of true chars.
+
+Physical Description: The back and sides are olive green or muddy gray, shading to white on the belly. The body has scattered pale yellow or pinkish-yellow spots. There are no black spots or wavy lines on the body or fins. Small red spots are present on the lower sides. These are frequently indistinct. The fins are plain and unmarked except for a few light spots on the base of the caudal fin rays. S. malma is extremely similar in appearance to the bull trout (S. confluentus) and Arctic char (S. alpinus), so much so that they are sometimes referred to as "native char" without a distinction.
+
+Range: The Dolly Varden trout is found in coastal waters of the North Pacific from Puget Sound north along the British Columbia Coast to the Alaska Peninsula and into the eastern Aleutian Islands, along the Bering Sea and the Arctic Sea to the Mackenzie River. The range in Asia extends south through the Kamchatka Peninsula into northern Japan.</dc:description>
+    <rdfs:label xml:lang="en">Salvelinus malma</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <skos:altLabel>S. malma</skos:altLabel>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-27T00:07:31Z</dc:date>
+    <j.4:hasDbXref>NCBI:txid8039
+ITIS: 162000 (https://www.itis.gov/servlet/SingleRpt/SingleRpt?search_topic=TSN&amp;search_value=162000#null)
+GBIF: 4284020 (https://www.gbif.org/species/4284020)
+EOL:  225241 (https://eol.org/pages/225241)
+COL: 79FQR (https://www.catalogueoflife.org/data/taxon/79FQR)
+Wikidata: Q327067 (https://www.wikidata.org/wiki/Q327067)</j.4:hasDbXref>
+    <skos:definition>The class which contains all instances of Salvelinus malma.</skos:definition>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000133">
+    <skos:definition>A fish length measurement taken from the middle of the orbit (i.e. eye) to the tip of the median caudal fin rays (i.e. fork).</skos:definition>
+    <skos:altLabel>MEFK
+Mid-eye to fork of tail</skos:altLabel>
+    <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/SALMON_00000632"/>
+    <rdfs:label xml:lang="en">Mid-orbit to fork of tail length</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T18:20:33Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000127"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000484">
+    <skos:definition>A variable that is not in itself directly measured but inferred, and that serves in place of an unobservable or immeasurable variable. In order for a variable to be a good proxy, it must have a close correlation, not necessarily linear, with the variable of interest. This correlation might be either positive or negative.</skos:definition>
+    <rdfs:label xml:lang="en">Proxy measurement type</rdfs:label>
+    <rdfs:comment>[ADDRESS COMMENT, THEN DELETE]
+
+This probably isn't the best place for this, since there may be proxy measures for non-fish measurement types; leaving for now but need input on the best way to model these in general</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T22:01:23Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000167"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000157">
+    <skos:definition>A gillnet which is kept afloat at the proper depth using a system of weights and buoys attached to the headrope, footrope, or floatline.</skos:definition>
+    <rdfs:label xml:lang="en">Drift gillnet</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T18:02:38Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000160"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000591">
+    <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/SALMON_00000570"/>
+    <j.4:hasDbXref>ITIS: 161989 (https://www.itis.gov/servlet/SingleRpt/SingleRpt?search_topic=TSN&amp;search_value=161989#null)
+GBIF: 5204019 (https://www.gbif.org/species/5204019)
+EOL: 46563138 (https://eol.org/pages/46563138, NOTE: refers to 'rainbow trout')
+COL: 49JFF (https://www.catalogueoflife.org/data/taxon/49JFF)
+Wikidata: Q64437771 (https://www.wikidata.org/wiki/Q64437771)</j.4:hasDbXref>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000642"/>
+    <skos:altLabel>O. mykiss</skos:altLabel>
+    <j.4:hasDbXref>NCBI:txid8022
+ITIS: 161989  (https://itis.gov/servlet/SingleRpt/SingleRpt?search_topic=TSN&amp;search_value=161989#null)
+GBIF: 5204019 (https://www.gbif.org/species/5204019)
+EOL: 46563138 (https://eol.org/pages/46563138)
+COL: 49JFF (https://www.catalogueoflife.org/data/taxon/49JFF)
+Wikidata: Q187986 (https://www.wikidata.org/wiki/Q187986)</j.4:hasDbXref>
+    <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/SALMON_00000642"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Oncorhynchus mykiss</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000587"/>
+    <skos:definition>The class which contains all instances of Oncorhynchus mykiss.</skos:definition>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-27T00:06:44Z</dc:date>
+    <dc:description>Oncorhynchus mykiss (i.e. rainbow trout) is a species of Pacific trout.
+
+Physical Description: Resident freshwater rainbow trout adults average between 1 and 5 lb (0.5 and 2.3 kg) in riverine environments, while lake-dwelling and anadromous forms may reach 20 lb (9 kg). Coloration varies widely between regions and subspecies. Adult freshwater forms are generally blue-green or olive green with heavy black spotting over the length of the body. Adult fish have a broad reddish stripe along the lateral line, from gills to the tail, which is most pronounced in breeding males. The caudal fin is squarish and only mildly forked. Lake-dwelling and anadromous forms are usually more silvery in color with the reddish stripe almost completely gone. Juvenile rainbow trout display parr marks (dark vertical bars) typical of most salmonid juveniles. In some redband and golden trout forms parr marks are typically retained into adulthood. Some coastal rainbow trout (O. m. irideus) and Columbia River redband trout (O. m. gairdneri) populations and cutbow hybrids may also display reddish or pink throat markings similar to cutthroat trout. In many regions, hatchery-bred trout can be distinguished from native trout via fin clips. Fin clipping the adipose fin is a management tool used to identify hatchery-reared fish.
+
+Range: The native range of Oncorhynchus mykiss is in the coastal waters and tributary streams of the Pacific basin, from the Kamchatka Peninsula in Russia, east along the Aleutian Islands, throughout southwest Alaska, the Pacific coast of British Columbia and southeast Alaska, and south along the west coast of the U.S. to northern Mexico. It is claimed that the Mexican forms of Oncorhynchus mykiss represent the southernmost native range of any trout or salmon (Salmonidae), though the Formosan landlocked salmon (O. masou formosanus) in Asia inhabits a similar latitude. The range of coastal rainbow trout (O. m. irideus) extends north from the Pacific basin into tributaries of the Bering Sea in northwest Alaska, while forms of the Columbia River redband trout (O. m. gairdneri) extend east into the upper Mackenzie River and Peace River watersheds in British Columbia and Alberta, Canada, which eventually drain into the Beaufort Sea, part of the Arctic Ocean. Since 1875, the rainbow trout has been widely introduced into suitable lacustrine and riverine environments throughout the United States and around the world. Many of these introductions have established wild, self-sustaining populations.</dc:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000240">
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000461"/>
+    <skos:altLabel>Oncorhynchus keta
+O. keta
+"dog salmon" @en
+"keta salmon" @en
+"silverbrite salmon" @en</skos:altLabel>
+    <skos:altLabel>"Iqalugruaq" @ipk
+"Aqalugruaq" @ipk
+"Noolaaghe" [Denaakk'e, Koyukon Athabaskan]
+"Nahdlii" @gwi
+"Shii" @gwi
+"Aluyak" @ypk
+"Iqalluk" @ypk
+"Kangitneq" @ypk
+"Mac'utaq" @ypk
+"Teggmaarrluk" @ypk [Unangam tunuu variant]
+"x̂aykix̂" @ale
+"Alimaq" [Alutiiq/Sugpiaq]
+"alima" [Kenai Dena'ina]
+"tiitl'" @eya
+"Gaynii"@tsi @tli
+"téel'" @tsi @tli</skos:altLabel>
+    <rdfs:label xml:lang="en">Chum salmon</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-16T18:10:52Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000482">
+    <rdfs:label xml:lang="en">Bycatch abundance</rdfs:label>
+    <rdfs:comment>Amount of Bycatch</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-26T23:38:07Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000499"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://rs.tdwg.org/dwc/terms/scientificName">
+    <skos:definition>The full scientific name, with authorship and date information if known. When forming part of an Identification, this should be the name in lowest level taxonomic rank that can be determined. This term should not contain identification qualifications, which should instead be supplied in the IdentificationQualifier term.</skos:definition>
+    <rdfs:comment>As of 30April2021, Darwin Core (DWC) does not specify domains and ranges. Currently, I am considering 'Vernacular name' to be the domain and 'Salmon specimen and occurrence' to be the range.</rdfs:comment>
+    <rdfs:range rdf:resource="http://purl.dataone.org/odo/SALMON_00000494"/>
+    <rdfs:domain rdf:resource="http://purl.dataone.org/odo/SALMON_00000458"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000483">
+    <skos:definition>The number of annuli on a given otolith.</skos:definition>
+    <rdfs:label xml:lang="en">Number of otolith annuli</rdfs:label>
+    <dc:description>Otoliths, or "earstones" (structures formed of calcium in the heads of bony fishes, and which function as organs of balance), grow concentrically from the center origin. Factors, such as watertemperature, that affect fish growth cause seasonal changes in the density of layers laid down in otoliths and in some cases it is possible to determine fish age from the banding that results. When otoliths are viewed under a low-power microscope, the layers making up spring and summer growth appear as a white, opaque band. Layers laid down in the fall, and also in the winter in some fishes, appear as a dark translucent band. A light and a dark band together make up the annual growth, and age in years is determined by counting the number of dark bands.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T21:37:46Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000234"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000156">
+    <skos:definition>A multi-pronged spear, typically ranging in length from 8 to 14 feet, which is used to spear (or "gig") fishes for harvest.</skos:definition>
+    <rdfs:label xml:lang="en">Gig</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T18:02:33Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000146"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000241">
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000460"/>
+    <skos:altLabel>Oncorhynchus gorbuscha
+O. gorbuscha
+"humpback salmon" @en
+"humpbacked salmon" @en</skos:altLabel>
+    <skos:altLabel>"Amaqtuq" @ipk
+"Amaqaayak" @ypk
+"Amaqsuq" @ypk
+"Cuqpeq" @ypk
+"Terteq" @ypk
+"Qungaayux" @ale [Unangam tunuu variant]
+"Amartuq" [Alutiiq/Sugpiaq]
+"Amaqaayak" [Alutiiq/Sugpiaq]
+"Dak'aay" [Ahtna]
+"Dak'aagi" [Ahtna]
+"qughuna" [Kenai Dena'ina]
+"giyah sdilahL" @eyk
+"kaashk'" @eyk
+"Sti'moon" @tsi @tli
+"Cháas'" @tsi @tli</skos:altLabel>
+    <rdfs:label xml:lang="en">Pink salmon</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-16T18:10:57Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000132">
+    <skos:definition>A fish length measurement taken from the mid-orbit (i.e. eye) to the posterior insertion of the anal fin.</skos:definition>
+    <skos:altLabel>Mid-eye to posterior insertion of anal fin</skos:altLabel>
+    <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/SALMON_00000634"/>
+    <rdfs:label xml:lang="en">Mid-orbit to posterior insertion of anal fin length</rdfs:label>
+    <dc:description>The insertion of a fin is the posterior-most point where the fin connects with the body.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T18:20:26Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000127"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000130">
+    <skos:definition>A fish length measurement taken from the hind margin of the orbit to the hypural plate.</skos:definition>
+    <skos:altLabel>POHL</skos:altLabel>
+    <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/SALMON_00000636"/>
+    <rdfs:label xml:lang="en">Post orbit to hypural plate length</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T18:19:49Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000127"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002114">
+    <rdfs:label xml:lang="en">geographic position measurement type</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-17T18:54:57Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#MeasurementType"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000590">
+    <skos:altLabel>S. salar</skos:altLabel>
+    <j.4:hasDbXref>NCBI:txid8030
+ITIS: 161996 (https://www.itis.gov/servlet/SingleRpt/SingleRpt?search_topic=TSN&amp;search_value=161996#null)
+GBIF: 7595433 (https://www.gbif.org/species/7595433)
+EOL: 46563143 (https://eol.org/pages/46563143)
+COL: 6XCXT (https://www.catalogueoflife.org/data/taxon/6XCXT)
+Wikidata: Q188879 (https://www.wikidata.org/wiki/Q188879)</j.4:hasDbXref>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000586"/>
+    <dc:description>Salmo salar is the only species of Atlantic salmon.
+
+Physical Description: Atlantic salmon are the largest species in their genus, Salmo. After two years at sea, the fish average 71 to 76 cm (28 to 30 in) in length and 3.6 to 5.4 kg (7.9 to 11.9 lb) in weight. The colouration of young Atlantic salmon does not resemble the adult stage. While they live in fresh water, they have blue and red spots. At maturity, they take on a silver-blue sheen. The easiest way of identifying them as an adult is by the black spots predominantly above the lateral line, though the caudal fin is usually unspotted. When they reproduce, males take on a slight green or red colouration. The salmon has a fusiform body, and well-developed teeth. All fins, except the adipose fin, are bordered with black.</dc:description>
+    <skos:definition>The class which contains all instances of Salmo salar.</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-27T00:02:46Z</dc:date>
+    <rdfs:label xml:lang="en">Salmo salar</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000589"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000709">
+    <skos:definition>Total number of recruits of age class 2.1.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 2.1 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:49:46Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000666"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000481">
+    <skos:definition>The number of salmon from a given population that escape the fishery in a day.</skos:definition>
+    <rdfs:label xml:lang="en">Daily escapement count</rdfs:label>
+    <rdfs:comment>Compare with "Annual escapement count"
+
+Need to think more about how to model time over which measurement is taken. E.g. do we want to have separate terms for annual escapement counts vs. daily escapement counts, OR have a predicate which encapsulates the time period over which a measurement occurs, OR something else?</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-26T23:24:56Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000479"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002247">
+    <rdfs:label xml:lang="en">latitude degree component</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-28T21:57:42Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002130"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A172">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Chum_salmon, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q475211, accessed 2021-06-15</j.4:hasDbXref>
+    <owl:annotatedTarget>Oncorhynchus keta (i.e. chum salmon) is one of the five species of Pacific salmon.
+
+Physical Description: The body of the chum salmon is deeper than most salmonid species. In common with other species found in the Pacific, the anal fin has 12 to 20 rays, compared with a maximum of 12 in European species. Chum have an ocean coloration of silvery blue green with some indistinct spotting in a darker shade, and a rather paler belly. When they move into fresh water the color changes to dark olive green and the belly color deepens. When adults are near spawning, they have purple blotchy streaks near the caudal peduncle, darker towards the tail. Spawning males typically grow an elongated snout or kype, their lower fins become tipped with white and they have enlarged teeth. Some researchers speculate these characteristics are used to compete for mates.
+
+Range: Chum salmon have the largest natural range of any Pacific salmon, and undergo the longest migrations within the genus Oncorhynchus, far up the Yukon River and deep into the Amur River basin in Asia. In lesser numbers they migrate thousands of kilometres up the Mackenzie River. Chum are found around the north Pacific, in the waters of Korea, Japan, and the Okhotsk and Bering seas (Kamchatka, Chukotka, Kuril Islands, Sakhalin, Khabarovsk Krai, Primorsky Krai), British Columbia in Canada, and from Alaska to California in the United States. In the Arctic Ocean they are found in limited numbers from the Laptev Sea to the Beaufort Sea. In North America chum salmon spawn from the Mackenzie River in the Arctic to as far south as Tillamook Bay, Oregon, although they were also reported in the San Lorenzo River near Santa Cruz, California in 1915 and the Sacramento River in northern California in the 1950s. In fall 2017 a half dozen chum salmon were counted in Lagunitas Creek about 25 miles (40 km) north of San Francisco, California.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000461"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000155">
+    <skos:definition>One or more fishing lines, which are baited with lures or bait fish and drawn through the water (often behind a moving vessel) to catch pelagic fishes.</skos:definition>
+    <rdfs:label xml:lang="en">Troll</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T18:02:30Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000142"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000131">
+    <skos:definition>A fish length measurement taken from the middle of the orbit (i.e. eye) to the hypural plate.</skos:definition>
+    <skos:altLabel>Mid-eye to hypural plate
+MEHL
+MEPS
+Mid-eye to posterior scale</skos:altLabel>
+    <rdfs:seeAlso rdf:resource="http://purl.dataone.org/odo/SALMON_00000633"/>
+    <rdfs:label xml:lang="en">Mid-orbit to hypural plate length</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T18:19:56Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000127"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A173">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Sockeye_salmon, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q44064, accessed 2021-06-15</j.4:hasDbXref>
+    <owl:annotatedTarget>Oncorhynchus nerka (i.e. sockeye salmon) is one of the five species of Pacific salmon.
+
+Physical Description: The sockeye salmon is sometimes called red or blueback salmon, due to its color. Sockeye are blue tinged with silver in color while living in the ocean. When they return to spawning grounds, their bodies become red and their heads turn green. Sockeye can be anywhere from 60 to 84 cm (2 ft 0 in–2 ft 9 in) in length and weigh from 2.3 to 7 kg (5–15 lb). Two distinguishing features are their long, serrated gill rakers that range from 30 to 40 in number, and their lack of a spot on their tail or back.
+
+Range: Sockeye salmon range as far south as the Columbia River in the eastern Pacific (although individuals have been spotted as far south as the 10 Mile River on the Mendocino Coast of California) and in northern Hokkaidō Island in Japan in the western Pacific. They range as far north as the Bathurst Inlet in the Canadian Arctic in the east and the Anadyr River in Siberia in the west. The farthest inland sockeye salmon travel is to Redfish Lake, Idaho, over 1,400 km (900 mi) from the ocean and 2,000 m (6,500 ft) in elevation. In the United States, populations of sockeye salmon have been extirpated from Idaho and Oregon.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000463"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/identifier">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/source">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000425">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <dc:description>Dissolved oxygen saturation can be measured with a dissolved oxygen probe such as an oxygen sensor or an optode in liquid media, usually water. The standard unit of oxygen saturation is percent (%).</dc:description>
+    <skos:exactMatch>http://purl.dataone.org/odo/ECSO_00002386</skos:exactMatch>
+    <rdfs:label xml:lang="en">Dissolved oxygen saturation</rdfs:label>
+    <skos:altLabel>DOsat</skos:altLabel>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-22T18:13:22Z</dc:date>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000424"/>
+    <skos:definition>A relative measure of the concentration of oxygen that is dissolved or carried in a given medium as a proportion of the maximal concentration that can be dissolved in that medium.</skos:definition>
+    <rdfs:comment>http://purl.dataone.org/odo/ECSO_00002386</rdfs:comment>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000776">
+    <rdfs:label xml:lang="en">Fish weight proxy measurement type</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-16T19:32:02Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000484"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000558">
+    <skos:definition>A small, electronic, sound-emitting device which may be placed inside or attached to a fish and collects information on that fish's physiology, environmentm and/or movement patterns.</skos:definition>
+    <rdfs:label xml:lang="en">Acoustic tag</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T23:05:51Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000545"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000643">
+    <rdfs:label xml:lang="en">Rainbow trout</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-15T20:05:20Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.2:scientificName rdf:resource="http://purl.dataone.org/odo/SALMON_00000580"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000591"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000126"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000752">
+    <skos:definition>Total number of recruits of age class 6.8.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 6.8 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:58:23Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000670"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000510">
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:sameAs rdf:resource="http://purl.dataone.org/odo/SALMON_00000515"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000462"/>
+    <j.2:vernacularName rdf:resource="http://purl.dataone.org/odo/SALMON_00000802"/>
+    <j.1:SALMON_00000617 rdf:resource="http://purl.dataone.org/odo/SALMON_00000615"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-30T17:44:59Z</dc:date>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000587"/>
+    <rdfs:label xml:lang="en">Oncorhynchus kisutch</rdfs:label>
+    <j.2:vernacularName rdf:resource="http://purl.dataone.org/odo/SALMON_00000515"/>
+    <j.2:nameAccordingTo rdf:resource="http://purl.dataone.org/odo/SALMON_00000475"/>
+    <j.1:SALMON_00000618 rdf:resource="http://purl.dataone.org/odo/SALMON_00000613"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002040">
+    <rdfs:label xml:lang="en">time of measurement</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-14T20:43:43Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002043"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000401">
+    <skos:definition>The age class or life stage of the biological individual(s) at the time the occurrence was recorded.</skos:definition>
+    <owl:equivalentClass>http://rs.tdwg.org/dwc/terms/lifeStage</owl:equivalentClass>
+    <rdfs:label xml:lang="en">Life history stage of salmonid fish</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T23:42:02Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000167"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000534">
+    <skos:definition>A small, electronic, sound-emitting device which is placed inside a fish and collects information on that fish's physiology and/or movement patterns.</skos:definition>
+    <rdfs:label xml:lang="en">Internal acoustic tag</rdfs:label>
+    <dc:description>This type of identification can remain in a fish for several years, is used for individual tagging, and is most suitable for fish that weigh at least 100g (given current technology). Tags may be inserted several different ways: (a) placed in a fish's stomach using a finger or guide, (b) implanted in the abdominal cavity, or (c) anchored inside the abdomen, usually to the abdominal wall with stiches. Data is transmitted wirelessly, usually through the use of radio waves (in fresh water and air), acoustic signals (in water; the receiver must also be in the water) or via satellite communication (in air; the tag sends data after it releases from the fish and floats up to the surface). Many types of telemetry devices also act as bio-loggers and store information locally on the device. Reading is done using the tag’s associated equipment, often through a computer connection.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:20:13Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000558"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000667">
+    <skos:definition>Total number of recruits of age class three.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 3.x recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-17T16:30:49Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000855"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A174">
+    <dc:source>http://www.fishbase.us/glossary/Glossary.php?q=adult&amp;language=english&amp;sc=is, accessed 2021-04-21</dc:source>
+    <owl:annotatedTarget>Fish that have fully developed morphological and meristic characters and that have attained sexual maturity.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000406"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A175">
+    <dc:source>https://en.wikipedia.org/wiki/Radio-frequency_identification, accessed 2021-05-05
+https://www.wikidata.org/wiki/Q104954, accessed 2021-05-05</dc:source>
+    <owl:annotatedTarget>An RFID system consists of a tiny transponder, a radio receiver, and an transmitter. When triggered by an electromagnetic interrogation pulse from a nearby FRID reader device, the tag transmits digital data, usually an identifying inventory number, back to the reader.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000550"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000557">
+    <skos:definition>The alteration of a physical bodily feature of a fish, either internally or externally, for identification purposes.</skos:definition>
+    <rdfs:label xml:lang="en">Fish body modification</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T17:26:06Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000530"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000666">
+    <skos:definition>Total number of recruits of age class two.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 2.x recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-17T16:30:43Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000855"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000642">
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000591"/>
+    <skos:altLabel>Oncorhychus mykiss
+O. mykiss
+"lake trout" @en
+"rainbow" @en
+"silver trout" @en
+"steelhead" @en
+"brook trout" @en</skos:altLabel>
+    <rdfs:label xml:lang="en">Rainbow trout</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-15T20:05:01Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000126"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000751">
+    <skos:definition>Total number of recruits of age class 6.7.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 6.7 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:58:16Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000670"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000884">
+    <rdfs:label xml:lang="en">Taxon (name)</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2022-02-04T02:06:35Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000829"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A176">
+    <dc:source>https://www.monitoringresources.org/Document/Method/Details/1548, accessed 2021-06-14</dc:source>
+    <owl:annotatedTarget>Measurements of specific parts of a fish are sometimes necessary when intact fish are not available. For instance, spawning or dead salmon often have eroded tails (from redd excavation) or enlarged or damaged jaws. When researchers want to compare fish lengths of male spawners versus female spawners or hatchery spawned females versus carcasses, it is a good idea to use this type of length measurement to remove the bias of the eroded tails on female spawners. So length measurements are made from specific parts of the body that are intact, such as the orbit and the hypural plate. The hypural plate is comprised of modified vertebrae that support the rays of the caudal fin and originate from the posterior end of the vertebral column.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000636"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000400">
+    <rdfs:label xml:lang="en">Immature</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T21:15:55Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000216"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000533">
+    <skos:definition>The use of a DNA sample to identify fish which have known biomarkers.</skos:definition>
+    <rdfs:label xml:lang="en">Genetic identification</rdfs:label>
+    <dc:description>There are four main methods for collecting tissue samples for DNA sequencing: (1) collecting a fin sample, (2) swabbing the mucus layer of the fish, (3) collecting a scale sample, and (4) blood sampling. Genetic identification can provide better answers to some questions that are also answered through typical fish marking and tagging, such as effective population size, whether populations differ and the degree of inbreeding. However, genetic identification cannot answer questions about, for example migration patterns, movement in the water and growth.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-04T23:17:57Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000530"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000424">
+    <skos:definition>The amount of gaseous oxygen (O2) dissolved in water.</skos:definition>
+    <skos:altLabel>DO</skos:altLabel>
+    <rdfs:label xml:lang="en">Dissolved oxygen measurement type</rdfs:label>
+    <rdfs:comment>An Essential Salmon Variable (ESV) from the working list being developed by Graeme Diack et al. at the Atlantic Salmon Trust.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-22T18:12:58Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000214"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A177">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>Gum cards are used to mount and label the identity of sampled fish scales.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000680"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002066">
+    <rdfs:label xml:lang="en">hour and minute of measurement time</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-16T00:19:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002040"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002393">
+    <rdfs:label xml:lang="en">station identifier</rdfs:label>
+    <rdfs:comment>Identifier associated, in some context, with a "station", i.e. a location  having some established facilities for doing scientific research</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-02-20T18:41:50Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000672"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002151">
+    <rdfs:label xml:lang="en">longitude minute component</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-17T22:52:26Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002132"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A178">
+    <dc:source rdf:resource="https://www.wikidata.org/wiki/Q934874"/>
+    <dc:source rdf:resource="https://en.wikipedia.org/wiki/Coho_salmon"/>
+    <owl:annotatedTarget>Oncorhynchus kisutch
+O. kisutch
+"silver salmon" @en
+"silvers" @en</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000243"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000665">
+    <skos:definition>Total number of recruits of age class one.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 1.x recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-17T16:30:32Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000855"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000205">
+    <skos:definition>The manner, procedure or technique by which a morphological or physiological state or property in a single individual or sample or a group of individuals or samples is assessed and a quantitative or qualitative value assigned.</skos:definition>
+    <rdfs:label xml:lang="en">Measurement method</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-12T23:21:32Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000883">
+    <rdfs:label xml:lang="en">Simultaneous hermaphrodite</rdfs:label>
+    <rdfs:comment>Used to designate that some individual or individuals in a group of organisms possessed functional qualities of more than one gender "simultaneously", i.e. "at one time" or within a single spawning event or season.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2022-02-03T22:55:07Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000488"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000641">
+    <skos:definition>An integer, which represents the sum of freshwater and marine annuli plus one to account for time spent in the gravel before hatching.</skos:definition>
+    <rdfs:label xml:lang="en">Fish total age</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-15T19:26:05Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000408"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000229">
+    <skos:definition>A stream that is usually smaller than a river.</skos:definition>
+    <skos:altLabel>Brook</skos:altLabel>
+    <rdfs:label xml:lang="en">Creek</rdfs:label>
+    <rdfs:comment>Term not currently in ENVO, will be submitted for consideration to ENVO curation team.  03AUG2021</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-15T18:50:11Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000194"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000750">
+    <skos:definition>Total number of recruits of age class 6.6.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 6.6 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:58:10Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000670"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A179">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>A colored marking, which is placed beneath the skin of a fish for identification.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000556"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A180">
+    <dc:source rdf:resource="http://purl.obolibrary.org/obo/PCO_0000074"/>
+    <owl:annotatedTarget>A community species diversity that is the mean species diversity at a site or within a specific habitat.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000625"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000532">
+    <skos:definition>A small metal pin which is inserted into the fish, usually into the cartilage of the snout.</skos:definition>
+    <skos:altLabel>CWT</skos:altLabel>
+    <rdfs:label xml:lang="en">Coded wire tag</rdfs:label>
+    <dc:description>This identification type will often last the entire life of the fish, is primarily used for group marking, and is most suitable for fish at least 2.5cm in length. The fish must be euthanized for reading. The tags are delivered on a spool, and the tagging machine magnetises, cuts and inserts the tag into the fish. While a detector can be used to determine if a fish is marked or not, a fish must be euthanized in order to remove the tag and read the engraved code.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-04T23:17:44Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000559"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000423">
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/ECSO_00001750"/>
+    <skos:definition>Alkalinity which is measured in seawater.</skos:definition>
+    <rdfs:label xml:lang="en">Seawater alkalinity</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-22T17:45:58Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000420"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000556">
+    <skos:definition>A colored marking, which is placed beneath the skin of a fish for identification.</skos:definition>
+    <rdfs:label xml:lang="en">Subcutaneous color mark</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T17:00:38Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000559"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2002/07/owl#Thing">
+    <rdfs:comment>search for '[NEEDS ALIGNMENT]' to find terms that should have owl:equivalentClass assertions (but were removed for now b/c Protege was having issues)</rdfs:comment>
+    <rdfs:comment>Salmonid species identification and classification still needs work.
+
+Instances of 'Pink salmon', for example, will not be inferred as instances of 'Oncorhynchus gorbuscha' (and vice versa) at the moment. Asserting owl:equivalentClass between these classes causes weird protege behavior after saving/closing/reopening Protege. Went with skos:exactMatch for now to avoid this problem.</rdfs:comment>
+    <rdfs:comment>search for '[ADDRESS COMMENT, THEN DELETE]' to find terms that need further review</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A181">
+    <rdfs:comment>https://en.wikipedia.org/wiki/Cutthroat_trout, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q2717060, accessed 2021-06-15</rdfs:comment>
+    <owl:annotatedTarget>Oncorhynchus clarkii (i.e. cutthroat trout) is a species of Pacific trout.
+
+Physical Description: Throughout their native and introduced ranges, cutthroat trout vary widely in size, coloration and habitat selection. Their coloration can range from golden to gray to green on the back. Cutthroat trout can generally be distinguished from rainbow trout by the presence of basibranchial teeth at the base of tongue and a maxillary that extends beyond the posterior edge of the eye. Depending on subspecies, strain and habitat, most have distinctive red, pink, or orange linear marks along the underside of their mandibles in the lower folds of the gill plates.
+
+At maturity, different populations and subspecies of cutthroat trout can range from 6 to 40 inches (15 to 102 cm) in length, depending on habitat and food availability. Sea-run forms of coastal cutthroat trout average 2 to 5 pounds (0.9 to 2.3 kg). The length and weights of mature inland forms vary widely depending on their particular environment and availability of food. Stream-resident fish are much smaller, 0.4 to 3.2 ounces (11 to 91 g), while lacustrine populations have attained weights ranging from 12 to 17 lb (5.4 to 7.7 kg) in ideal conditions. The largest cutthroat trout subspecies is the Lahontan cutthroat trout (O. c. henshawi). These fish average 8 to 9 in (20 to 23 cm) in small streams and 8 to 22 in (20 to 56 cm) in larger rivers and lakes. In ideal environments, the Lahontan cutthroat trout attains typical weights of 0.25 to 8 lb (0.11 to 3.63 kg). The world record cutthroat trout is a Lahontan at 39 in (99 cm) and 41 lb (19 kg).
+
+Range: Cutthroat trout are native to western North America and have evolved through geographic isolation into 14 subspecies, each native to a different major drainage basin. Native cutthroat trout species are found along the Pacific Northwest coast from Alaska through British Columbia into northern California, in the Cascade Range, the Great Basin and throughout the Rocky Mountains including southern Alberta. Some coastal populations of the coastal cutthroat trout (O. c. clarkii) are semianadromous, spending a few months in marine environments to feed as adults and returning to fresh water from fall through early spring to feed on insects and spawn. Cutthroat trout have the second-largest historic native range of North American trout; the lake trout (Salvelinus namaycush) having the largest. Ranges of some subspecies, particularly the westslope cutthroat trout (O. c. lewisi), have been reduced to less than 10 percent of their historic range due to habitat loss and introduction of non-native species.
+
+Although members of Oncorhynchus, the Pacific trout/salmon species, three subspecies—the westslope (O. c. lewisi), the greenback (O. c. stomias) and Yellowstone cutthroat trout (O. c. bouvierii)—evolved populations east of the Continental Divide in the upper Missouri River basin, upper Arkansas and Platte River basins and upper Yellowstone River basin, each which drain into the Atlantic basin via the Mississippi River. Scientists believe that the climatic and geologic conditions 3-5 million years ago allowed cutthroat trout from the Snake River to migrate over the divide into the Yellowstone plateau via Two Ocean Pass. There is also evidence that Yellowstone Lake once drained south into the Snake River drainage. Evidence suggests that the westslope cutthroat trout was able to establish populations east of the divide via Summit Lake at Marias Pass which at one time connected the Flathead River drainage with the upper Missouri River drainage. Scientists speculate that there are several mountain passes associated with the headwaters of the Colorado River drainage and Arkansas/Platte River drainages that would have allowed migration of cutthroat trout east of the divide.
+
+Cutthroat trout have been introduced into non-native waters outside their historic native range, but not to the extent of the rainbow trout (O. mykiss). Within the native range of the Yellowstone cutthroat trout, U.S. Fisheries Bureau and National Park Service authorities introduced Yellowstone cutthroat trout into many fishless lakes in Yellowstone National Park. Cutthroat trout were introduced into Lake Michigan tributaries in the 1890s and sporadically in the early 20th century, but never established wild populations. A population of Yellowstone cutthroat trout purportedly has been established in Lake Huron. Although cutthroat trout are not native to Arizona, they are routinely introduced by the Arizona Game and Fish Department into high mountain lakes in the White Mountains in the northeastern region of that state.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000594"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A182">
+    <dc:source rdf:resource="http://purl.dataone.org/odo/ECSO_00001237"/>
+    <owl:annotatedTarget>Volume of precipitation, which is any product of the condensation of atmospheric water vapor that falls under gravity.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000623"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000228">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/ENVO_00000476</skos:exactMatch>
+    <skos:definition>An opening of a lake into its shore.</skos:definition>
+    <rdfs:label xml:lang="en">Lake inlet</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-15T18:47:50Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000222"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000688">
+    <skos:definition>The number of sea lice counted on an individual fish.</skos:definition>
+    <rdfs:label xml:lang="en">Sea lice count</rdfs:label>
+    <dc:description>A sea louse (plural sea lice, not to be confused with sea fleas), is a member of the Caligidae family of copepods (small crustaceans) within the order Siphonostomatoida. The roughly 559 species in 37 genera include around 162 Lepeophtheirus and 268 Caligus species. Sea lice are marine ectoparasites (external parasites) that feed on the mucus, epidermal tissue, and blood of host marine fish.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-23T18:54:56Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000687"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000664">
+    <skos:definition>Total number of recruits of age class zero.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 0.x recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-17T16:30:26Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000855"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000773">
+    <skos:definition>Total number of recruits of age class 8.9.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 8.9 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T19:36:45Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000755"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A183">
+    <rdfs:comment>Indigenous names for salmon can be found by exploring each SASAP region's page on the State of Alaska's Salmon and People website (for example, see the Arctic Region here: https://alaskasalmonandpeople.org/region/arctic/)</rdfs:comment>
+    <dc:source>https://alaskasalmonandpeople.org/regions/, accessed 2021-04-16</dc:source>
+    <owl:annotatedTarget>"Cayak" @ypk
+"Sayak" @ypk
+"Niklliq" [Alutiiq/Sugpiaq]
+"Nulaeggi" [Ahtna]
+"Sesluugge"' [Ahtna]
+"Natael luugge'" [Ahtna]
+"k'q'uya" [Kenai Dena'ina]
+"tahi'id" @eyk
+"cha'ch" @eyk
+"Misoo" @tsi @tli
+"g̲aat" @tsi @tli</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000242"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A184">
+    <dc:source>http://www.fishbase.us/glossary/Glossary.php?q=parr&amp;language=english&amp;sc=is, accessed 2021-06-15</dc:source>
+    <owl:annotatedTarget>A young salmonid (salmon or trout) with parr-marks before migration to the sea and after dispersal from the redd.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000649"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000640">
+    <skos:relatedMatch rdf:resource="http://purl.obolibrary.org/obo/PCO_0000001"/>
+    <skos:definition>A stock that is sustained by natural spawning and rearing in the natural habitat, regardless of parentage or origin.</skos:definition>
+    <rdfs:label xml:lang="en">Wild stock</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-14T23:05:21Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000639"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000882">
+    <rdfs:label xml:lang="en">Sequential hermaphrodite</rdfs:label>
+    <rdfs:comment>Used to designate that some individual or individuals in a group of organisms possessed functional qualities of more than one gender "sequentially", i.e. not at the "same time" or within a single spawning event or season, but more typically across spawning events or seasons.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2022-02-03T22:54:57Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000488"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A185">
+    <dc:source rdf:resource="http://purl.obolibrary.org/obo/PCO_0000075"/>
+    <owl:annotatedTarget>A community species diversity that is the ratio between regional and local species diversity.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000626"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000422">
+    <skos:exactMatch>http://purl.dataone.org/odo/ECSO_00002895</skos:exactMatch>
+    <skos:definition>Alkalinity which is measured in freshwater.</skos:definition>
+    <rdfs:label xml:lang="en">Freshwater alkalinity</rdfs:label>
+    <rdfs:comment>An Essential Salmon Variable (ESV) from the working list being developed by Graeme Diack et al. at the Atlantic Salmon Trust.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-22T17:45:49Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000420"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000204">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/ENVO_00000016</skos:exactMatch>
+    <skos:definition>A large expanse of saline water usually connected with an ocean.</skos:definition>
+    <rdfs:label xml:lang="en">Sea</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-12T21:38:14Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000203"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002392">
+    <rdfs:label xml:lang="en">station name</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-02-20T18:28:45Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000878"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000555">
+    <skos:definition>An ink solution, which is injected into the skin.</skos:definition>
+    <rdfs:label xml:lang="en">Tattoo</rdfs:label>
+    <dc:description>This type of identification is usually visible for one year on salmon, is primarily used for group marking, and is suitable for fish that weigh at least 20g. An ink solution (often Alcian blue dissolved in distilled water) is typically injected under the skin using a syringe with a cannula. Marking a fish using the "square dot system" with up to 3x3 dots is common. Unlike VIE, tattoos do not require transparent skin to be visible. However, in salmon, the tattoo should be placed in areas in front of the pelvic fins, under the pectoral fins and/or behind the anal fins to enable reading during spawning, when the fish's natural pigmentation may cover up the tattoo.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T17:00:08Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000556"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002044">
+    <rdfs:label xml:lang="en">measurement start time</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-14T21:55:20Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002040"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002068">
+    <rdfs:label xml:lang="en">elapsed time</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-16T00:27:36Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00001183"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A186">
+    <dc:source>http://orcid.org/0000-0002-5300-3075</dc:source>
+    <owl:annotatedTarget>A measurement type taken of some physical, biological, or ecological aspect of a fish or fishes.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000167"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A187">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>The unique alphanumeric code or marking color(s) of a tagged fish.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000524"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000227">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/ENVO_00000039</skos:exactMatch>
+    <skos:definition>A long and narrow sea inlet with high steeply sloped walled sides. A fjord is a landform created during a period of glaciation.</skos:definition>
+    <rdfs:label xml:lang="en">Fjord</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-15T18:40:03Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000223"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000687">
+    <rdfs:label xml:lang="en">Fish parasite measurement type</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-23T18:53:19Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000167"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://rs.tdwg.org/dwc/terms/originalNameUsage">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000663">
+    <skos:definition>The number of salmon which survive to reach legal age and/or size for harvest. Recruits include both individuals that are captured by a fishery and individuals that escape the fishery -- total recruitment is calculated as catch plus escapement.</skos:definition>
+    <rdfs:label xml:lang="en">Total recruit abundance</rdfs:label>
+    <dc:description>Recruits do not include individuals lost to predation.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-17T16:16:10Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000781"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000772">
+    <skos:definition>Total number of recruits of age class 8.8.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 8.8 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T19:36:40Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000755"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A188">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05
+
+https://en.wikipedia.org/wiki/Acoustic_tag, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>A small, electronic, sound-emitting device which is attached externally to a fish and collects information on fish movement patterns and the physical environment.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000546"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000530">
+    <skos:definition>A marking which is used to differentiate individual fish or groups of fish(es).</skos:definition>
+    <rdfs:label xml:lang="en">Fish tag or identification type</rdfs:label>
+    <rdfs:comment>An overview of many popular tag types and methods: https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-04T22:55:08Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000554">
+    <skos:definition>A colored two-component plastic which is injected into the fish's epidermis or fins.</skos:definition>
+    <skos:altLabel>VIE</skos:altLabel>
+    <rdfs:label xml:lang="en">Visible implant elastomer</rdfs:label>
+    <dc:description>When done correctly, this identification type will remain visible for the entire lifetime of the fish and can be used for group or individual marking. Neon or fluorescent colors are often used, and best placement is in light areas and fin rays, though even semi-transparent and transparent tissue may be suitable for easy visual reading.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:58:54Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000556"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000203">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/ENVO_00001999</skos:exactMatch>
+    <skos:definition>A significant accumulation of saline water which is part of a marine biome.</skos:definition>
+    <skos:altLabel>marine waterbody
+body of marine water</skos:altLabel>
+    <rdfs:label xml:lang="en">Marine water body</rdfs:label>
+    <dc:description>On average, seawater in the world's oceans has a salinity of about 3.5% (35 g/l, 35 ppt, 599 mM).</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-12T21:36:50Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000197"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002043">
+    <rdfs:label xml:lang="en">date and time of measurement</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-14T21:16:02Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00001167"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A189">
+    <rdfs:comment>Chose not to assert owl:equivalentClass here, because all Rainbow trout are Oncorhynchus mykiss, but not all Oncorhynchus mykiss are considered Rainbow trout.</rdfs:comment>
+    <owl:annotatedTarget rdf:resource="http://purl.dataone.org/odo/SALMON_00000642"/>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000591"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A190">
+    <dc:source>https://en.wikipedia.org/wiki/Taxonomy_(biology), accessed 2021-04-28</dc:source>
+    <owl:annotatedTarget>For example, in 1758 Linnaeus gave the Asian elephant the scientific name Elephas maximus, so the name is sometimes written as "Elephas maximus Linnaeus, 1758".</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000495"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A191">
+    <dc:source>https://www.fishbase.in/glossary/Glossary.php?q=standard+length, accessed 2021-03-31</dc:source>
+    <owl:annotatedTarget>The measurement from the most anterior tip of the body to the midlateral posterior edge of the hypural plate (in fish with a hypural plate) or to the posterior end of the vertebral column (in fish lacking hypural plates).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000135"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A192">
+    <rdfs:comment>"POFK" is an acronym used by Alaska Department of Fish &amp; Game (ADF&amp;G)</rdfs:comment>
+    <owl:annotatedTarget>POFK</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000129"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002067">
+    <rdfs:label xml:lang="en">hours elapsed</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-16T00:23:41Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002068"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A193">
+    <dc:source>http://purl.obolibrary.org/obo/ENVO_01000617</dc:source>
+    <owl:annotatedTarget>A water body in which the accumulated water, in its totality, has very little to no directed flow.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000197"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/description">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000686">
+    <skos:definition>The weight of a specimen's stomach, taken after the stomach has been dissected from the fish and emptied of its contents.</skos:definition>
+    <rdfs:label xml:lang="en">Weight of empty stomach</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-23T18:47:15Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000684"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A194">
+    <dc:source>https://www.fisheries.noaa.gov/national/bycatch/fishing-gear-gillnets</dc:source>
+    <owl:annotatedTarget>A gillnet which is kept afloat at the proper depth using a system of weights and buoys attached to the headrope, footrope, or floatline.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000157"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000662">
+    <skos:definition>A group of individuals of the same species that have the same age.</skos:definition>
+    <rdfs:label xml:lang="en">Age class</rdfs:label>
+    <dc:description>For example, salmon of age class 2 include all individuals in a population of interest that are two years old.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-17T16:11:34Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000187"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000771">
+    <skos:definition>Total number of recruits of age class 8.7.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 8.7 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T19:36:34Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000755"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000420">
+    <skos:exactMatch>http://purl.dataone.org/odo/ECSO_00001749</skos:exactMatch>
+    <skos:definition>A measure of the quantitative capacity of an aqueous solution to neutralize an acid.</skos:definition>
+    <rdfs:label xml:lang="en">Alkalinity measurement type</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-22T17:28:15Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000214"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000553">
+    <skos:definition>The appearance of the otoliths (located in the inner ear of the fish) are changed.</skos:definition>
+    <rdfs:label xml:lang="en">Otolith marking</rdfs:label>
+    <dc:description>This identification type will last the entire life of the fish and is primarily used for group marking, though the fish must be euthanized for reading. Altering the appearance of otoliths may be achieved in a variety of ways, including (a) exposing a fish to variations in water temperature of at least 3 degrees Celsius a number of times to create darker and lighter bands in the otoliths, (b) bathing the fish or eggs in an aqueous solution with fluorescent dye, which is absorbed into the otoliths, or (c)  bathing the fish in strontium chloride solution or feeding the fish food that contains the metallic substance strontium.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:55:56Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000557"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000202">
+    <skos:definition>A material entity which determines an environmental system.</skos:definition>
+    <owl:equivalentClass>http://purl.obolibrary.org/obo/ENVO_00002297</owl:equivalentClass>
+    <rdfs:label xml:lang="en">Environmental feature</rdfs:label>
+    <rdfs:comment>This Class and all its Subclasses are taken from the Environment Ontology, ENVO-- where the Class "Environmental feature" is now deprecated.
+
+To address this issue, we have imported the "astronomical-body-parts--hierarchy.owl" file from the ENVO ontology framework into this Salmon ontology.  That subset of ENVO includes all the relevant subclass terms included here, except for "Creek".  We will put in a request to ENVO curators to add the term "Creek", probably as a subclass of "Stream".
+
+Aside from Creek, we would recommend using the Classes included under the ENVO "water body" Class hierarchy for annotation of Salmon data as to "features" of their habitat, because these are more comprehensive than the terms in this native "salmon ontology" subClass hierarchy.
+
+(Mark Schildhauer, 2021Jul20)</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-12T19:49:29Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000226">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/ENVO_00000393</skos:exactMatch>
+    <skos:definition>A large sea or ocean inlet larger than a bay, deeper than a bight, wider than a fjord, or it may identify a narrow sea or ocean channel between two bodies of land.</skos:definition>
+    <rdfs:label xml:lang="en">Sound</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-15T18:39:58Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000223"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A195">
+    <dc:source>https://en.wikipedia.org/wiki/Region</dc:source>
+    <owl:annotatedTarget>In geography, regions are areas that are broadly divided by physical characteristics (physical geography), human impact characteristics (human geography), and the interaction of humanity and the environment (environmental geography). Geographic regions and sub-regions are mostly described by their imprecisely defined, and sometimes transitory boundaries, except in human geography, where jurisdiction areas such as national borders are defined in law.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000678"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000685">
+    <skos:definition>The weight of a specimen's stomach, taken after the stomach has been dissected from the fish but before being emptied of its contents.</skos:definition>
+    <rdfs:label xml:lang="en">Weight of full stomach</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-23T18:47:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000684"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A196">
+    <dc:source>https://www.salmonography.com/Salmonid-Topic/Jack-Salmon/</dc:source>
+    <owl:annotatedTarget>Jacks are precocial male salmon that have spent one winter less in the ocean than the youngest females of a given species. Because they are younger, jack salmon are smaller than other age classes of conspecifics. Coho jacks return to spawn the same year they smolted and so are particularly small. Jack coloration can differ from that of older adults. Jacks are able to successfully sneak-spawn in spite of efforts by the female and occasionally the other males.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000805"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A197">
+    <dc:source>https://www.seagrant.wisc.edu/our-work/focus-areas/fish-and-fisheries/fish-glossary/, accessed 2021-03-31</dc:source>
+    <owl:annotatedTarget>The insertion of a fin is the posterior-most point where the fin connects with the body.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000132"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000661">
+    <skos:definition>The typical or expected weight at a given total length for a specific species of fish. Most standard weight equations are for freshwater fish species.</skos:definition>
+    <rdfs:label xml:lang="en">Standard weight</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-16T22:57:49Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000683"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000770">
+    <skos:definition>Total number of recruits of age class 8.6.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 8.6 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T19:36:25Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000755"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000552">
+    <skos:definition>An appearance that varies between individuals.</skos:definition>
+    <rdfs:label xml:lang="en">Natural pattern or unique marking</rdfs:label>
+    <dc:description>Natural patterns or unique markings are primarily used for identification of individuals. This type of identification does not involve marking a fish in any way, but rather relies on stable and individual differences in appareance, such as color, patterns, and scars. This method is based on the use of still images or videos taken of individual fish, which are then analyzed manually or using digital image processing.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:54:30Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000530"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000201">
+    <skos:definition>An age designation notation that includes two numbers, of which the second is a subscript. The first numeral indicates the total age of the fish and the subscript indicates the time spent in freshwater prior to saltwater immigration.</skos:definition>
+    <skos:altLabel>G-R notation
+G-R</skos:altLabel>
+    <rdfs:label xml:lang="en">Fish age (Gilbert-Rich notation)</rdfs:label>
+    <dc:description>e.g. An age written in Gilbert-Rich notation as '5sub2' (spoken as "five sub two") is interpreted as a fish that is in its fifth year of life (i.e. a fish that will be 5 on its next "birthday" or the number of winters from its deposition in the gravel as an egg to the time of sampling) and which migrated to the ocean during its second year of life. The European notation equivalent age is written as '1.3'.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-09T18:52:00Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000408"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A198">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Atlantic_Ocean, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q97, accessed 2021-06-15</j.4:hasDbXref>
+    <owl:annotatedTarget>An ocean bounded on the west by North and South America. In the north and northeast, it is separated from the Arctic Ocean by the Canadian Arctic Archipelago, Greenland, Iceland, Svalbard, and mainland Europe. It connects to the Arctic Ocean through the Denmark Strait, Greenland Sea, Norwegian Sea, and Barents Sea. To the east, the boundaries of the ocean proper are Europe, the Strait of Gibraltar (where it connects with the Mediterranean Sea, one of its marginal seas), and Africa. In the southeast, the Atlantic merges into the Indian Ocean, the border being defined by the 20 East meridian, running south from Cape Agulhas to Antarctica.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000584"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000225">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/ENVO_00000138</skos:exactMatch>
+    <skos:definition>A circular or round inlet with a narrow entrance.</skos:definition>
+    <rdfs:label xml:lang="en">Cove</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-15T18:39:55Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000223"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A199">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>A marking which is used to differentiate individual fish or groups of fish(es).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000530"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002130">
+    <rdfs:label xml:lang="en">latitude coordinate</rdfs:label>
+    <dc:description>In geography, latitude is a geographic coordinate that specifies the north–south position of a point on the Earth's surface. Latitude is an angle (defined below) which ranges from 0° at the Equator to 90° (North or South) at the poles. Lines of constant latitude, or parallels, run east–west as circles parallel to the equator. Latitude is used together with longitude to specify the precise location of features on the surface of the Earth. On its own, the term latitude should be taken to be the geodetic latitude as defined below. Briefly, geodetic latitude at a point is the angle formed by the vector perpendicular (or normal) to the ellipsoidal surface from that point, and the equatorial plane. Also defined are six auxiliary latitudes that are used in special applications.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-17T18:57:21Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002269"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A200">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Dolly_Varden_trout, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q327067, accessed 2021-06-15</j.4:hasDbXref>
+    <owl:annotatedTarget>Salvelinus malma (i.e. the dolly varden trout) is a species of Pacific trout, belonging to the genus Salvelinus of true chars.
+
+Physical Description: The back and sides are olive green or muddy gray, shading to white on the belly. The body has scattered pale yellow or pinkish-yellow spots. There are no black spots or wavy lines on the body or fins. Small red spots are present on the lower sides. These are frequently indistinct. The fins are plain and unmarked except for a few light spots on the base of the caudal fin rays. S. malma is extremely similar in appearance to the bull trout (S. confluentus) and Arctic char (S. alpinus), so much so that they are sometimes referred to as "native char" without a distinction.
+
+Range: The Dolly Varden trout is found in coastal waters of the North Pacific from Puget Sound north along the British Columbia Coast to the Alaska Peninsula and into the eastern Aleutian Islands, along the Bering Sea and the Arctic Sea to the Mackenzie River. The range in Asia extends south through the Kamchatka Peninsula into northern Japan.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000593"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002069">
+    <skos:altLabel>minute of hour</skos:altLabel>
+    <rdfs:label xml:lang="en">minute of measurement time</rdfs:label>
+    <j.4:hasExactSynonym>minute of hour</j.4:hasExactSynonym>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-16T00:29:17Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002040"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002045">
+    <rdfs:label xml:lang="en">measurement end time</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-14T21:55:34Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002040"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A201">
+    <dc:source>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</dc:source>
+    <owl:annotatedTarget>A colored two-component plastic which is injected into the fish's epidermis or fins.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000554"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A202">
+    <dc:source>https://en.wikipedia.org/wiki/Identifier, accessed 2021-06-22
+https://www.wikidata.org/wiki/Q853614, accessed 2021-06-22</dc:source>
+    <owl:annotatedTarget>A name that identifies (that is, labels the identity of) either a unique object or a unique class of objects, where the "object" of class may be an idea, physical countable object (of class thereof), or physical noncountable substance (or class thereof). The abbreviation ID often refers to identity, identification (the process of identifying), or an identifier (that is, an instance of identification). An identifier may be a word, number, letter, symbol, or any combination of those.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000672"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A203">
+    <dc:source>https://en.wikipedia.org/wiki/Creek, accessed 2021-04-15
+https://www.wikidata.org/wiki/Q63565252, accessed 2021-04-15</dc:source>
+    <owl:annotatedTarget>A stream that is usually smaller than a river.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000229"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000684">
+    <rdfs:label xml:lang="en">Stomach weight</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-23T18:46:59Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000658"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000660">
+    <skos:definition>The weight of a fish, taken after the specimen has been frozen.</skos:definition>
+    <rdfs:label xml:lang="en">Frozen weight</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-16T22:54:03Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000683"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A204">
+    <dc:source>https://www.fishbase.se/Glossary/Glossary.php?q=wild+stock&amp;language=english&amp;sc=is, accessed 2021-06-15</dc:source>
+    <owl:annotatedTarget>A stock that is sustained by natural spawning and rearing in the natural habitat, regardless of parentage or origin.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000640"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000551">
+    <skos:definition>This identification type may last for several years or up to the lifetime of a fish, and is used for individual tagging. The tag is placed in the abdominal cavity or in the muscular tissue. Reading PIT tags can be done (a) automatically by detecting fish as they swim past (this is usually done by building an obstacle so that fish must pass close to the reader), or (b) manually by taking the fish up in the air to be scanned with a reader.</skos:definition>
+    <skos:definition>A small, passive (i.e. does not actively send out a signal and does not require a battery) radio transponder tag which, when in range, is activated by a signal emitted from a tag reader. The tag then emits a unique identification code back to the reader.</skos:definition>
+    <skos:altLabel>Passive Integrated Transponder tag
+Microchip</skos:altLabel>
+    <rdfs:label xml:lang="en">PIT tag</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:47:58Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000550"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000200">
+    <skos:definition>An age designation notation that includes two number separated by a period. The first number represents the number of years or winters a salmon has spent in freshwater after emergence from the gravel, and the second number represents the number of years spent in the ocean. Added together, these numbers can provide the total age or age class of a salmon. (although see Comment for further detail).</skos:definition>
+    <rdfs:label xml:lang="en">Fish age (European notation)</rdfs:label>
+    <rdfs:comment>The European Age System Designation is based on a count of Freshwater (FW) and Saltwater (SW) Annuli in recruit otoliths, represented as "number of FW annuli" "." "number of SW annuli", e.g "1.4" indicating 1 FW annulus and 4 SW annuli.
+
+Some interpret the "Total Age" of a recruit with an "Age designation= 0.0"  as a 1-year old salmon, while others interpret "Total Age" as a 0-year old salmon.
+
+That is, in some cases "Total Age" might be reported FW+SW+1, while in other cases it would simply be FW+SW:
+
+1.3=total age of 4, or 5 years
+2.3=total age of 5, or 6 years</rdfs:comment>
+    <dc:description>e.g. An age written in European notation as '1.3' is interpreted as 1 year over-wintered in freshwater and 3 years in the ocean. The total age is 4 years (1 + 3 years). The Gilbert-Rich equivalent age is written as '5sub2'.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-09T18:49:30Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000408"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000224">
+    <skos:definition>An area of water bordered by land on three sides.</skos:definition>
+    <rdfs:label xml:lang="en">Bay</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-15T18:39:18Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000223"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000599">
+    <rdfs:label xml:lang="en">Salmo salar</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-27T19:45:43Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.2:vernacularName rdf:resource="http://purl.dataone.org/odo/SALMON_00000601"/>
+    <j.2:nameAccordingTo rdf:resource="http://purl.dataone.org/odo/SALMON_00000588"/>
+    <j.1:SALMON_00000618 rdf:resource="http://purl.dataone.org/odo/SALMON_00000612"/>
+    <j.1:SALMON_00000617 rdf:resource="http://purl.dataone.org/odo/SALMON_00000615"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000589"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A205">
+    <j.4:hasDbXref>https://www.fws.gov/guidance/sites/default/files/documents/Calcein_%28SE%20Mark%29_Study_Protocol.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>Tag based on application of a dilution of fluorochrome dye in which fish are immersed and which binds to bony structures (such as fin rays, jaw bones, and scales), manifesting as a green fluorescence.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000537"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A206">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Electrofishing, accessed 2021-04-01
+https://www.wikidata.org/wiki/Q1249133, accessed 2021-04-01</j.4:hasDbXref>
+    <owl:annotatedTarget>A type of fishing gear which uses direct current electricity flowing between a submerged cathod and anode to cause galvanotaxis, or an uncontrolled muscular convulsion, which affects the movement of the fish such that it swims towards the anode, where it is then collected.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000159"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000518">
+    <rdfs:label xml:lang="en">Year of fish harvest</rdfs:label>
+    <rdfs:comment>The Year in which some commercial fish harvest was taken.  Given a Class structure here to enable filtering by Year(s) of interest, although this temporal descriptor could and should also be assigned to any observations of "Commercial Fish Harvest", e.g. potentially by using the SOSA:PhenomenonTime attribute.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-04T17:21:40Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002050"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A207">
+    <dc:source>https://www.monitoringresources.org/Document/Method/Details/1549, accessed 2021-03-31</dc:source>
+    <owl:annotatedTarget>A fish length measurement taken from the middle of the orbit (i.e. eye) to the hypural plate.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000131"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A208">
+    <j.4:hasDbXref>https://spo.nmfs.noaa.gov/sites/default/files/legacy-pdfs/leaflet488.pdf, accessed 2021-04-15</j.4:hasDbXref>
+    <owl:annotatedTarget>A method which is used to approximate the age of a fish, and which generally involves removing and preserving a scale from a fish, then counting the number of annuli (i.e. year marks).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000231"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A209">
+    <dc:source>http://orcid.org/0000-0002-5300-3075</dc:source>
+    <owl:annotatedTarget>Objective comparative measure of hot or cold of water temperature in an aquatic environment.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000236"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A210">
+    <j.4:hasDbXref>https://www.researchgate.net/profile/Darlene-Gillespie/publication/281285926_Chinook_Salmon_Oncorhynchus_tshawytscha_Scale_Age_Determination_Procedures/links/55df66d708aede0b572b8de7/Chinook-Salmon-Oncorhynchus-tshawytscha-Scale-Age-Determination-Procedures.pdf, accessed 2021-04-06</j.4:hasDbXref>
+    <owl:annotatedTarget>The number of years or winters a salmon spends in a freshwater environment as a free-swimming fish.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000188"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000627">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/PCO_0000076</skos:exactMatch>
+    <skos:definition>A community species diversity that is the total species diversity in a landscape. The area or landscape of interest may be of very different sizes in different situations, but it should encompass multiple sites or habitats as measured by alpha diversity.</skos:definition>
+    <skos:altLabel>γ-diversity</skos:altLabel>
+    <rdfs:label xml:lang="en">Gamma diversity</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-04T22:01:04Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000624"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A211">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>The right pectoral fin of the fish is removed.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000561"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000736">
+    <skos:definition>Total number of recruits of age class 5.1.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 5.1 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:55:44Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000669"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000845">
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000464"/>
+    <rdfs:label xml:lang="en">King salmon</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-10-07T01:05:10Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000603">
+    <rdfs:label xml:lang="en">Cutthroat trout</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-27T19:58:56Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.2:scientificName rdf:resource="http://purl.dataone.org/odo/SALMON_00000598"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000594"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000126"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A212">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Fishery, accessed 2021-04-01
+https://www.wikidata.org/wiki/Q180538, accessed 2021-04-01
+http://www.fao.org/faoterm/en/?defaultCollId=21, accessed 2021-04-01
+
+Fletcher, W.J., Chesson, J. Fisher, M., Sainsbury K.J., Hundloe, T. Smith A.D.M., and B. Whitworth (2002): National ESD reporting framework for Australian fisheries: The "How To" guide for wild capture fisheries. FRDC Project 2000/145. Canberra, Australia</j.4:hasDbXref>
+    <owl:annotatedTarget>The Food and Agriculture Organization of the United Nations (FAO) defines a fishery as "...an activity leading to harvesting of fish. It may involve capture of wild fish or raising of fish through aquaculture."</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000137"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000712">
+    <skos:definition>Total number of recruits of age class 2.4.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 2.4 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:50:08Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000666"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A213">
+    <dc:source>https://www.monitoringresources.org/Document/Method/Details/1551, accessed 2021-06-14</dc:source>
+    <owl:annotatedTarget>A fish measurement method in which the length from the most anterior tip of the body to the tip of the longest caudal fin rays is recorded.
+Total length can be measured by two conventions -- by leaving the caudal fin spread in a natural position or by compressing the lobes of the caudal fin dorsoventrally. Two common procedures are:
+
+(a) Using a measuring board: A fish is placed on its side on a measuring board with its snout against the rigid headpiece. A measurement is taken from the most anterior tip of the body to the tip of the longest caudal fin rays.
+
+(b) Using a tape measure: A fish is placed on its side, either on top of a tape measure or the tape measure is placed just above the dorsal side of the fish to record the measurement from the most anterior tip of the body to the tip of the longest caudal fin rays. It is important to not allow the tape to curve along the contoured side of the fish that is facing up, which can introduce bias into the measurement due to girth.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000638"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A214">
+    <dc:source>https://en.wikipedia.org/wiki/Coastal_cutthroat_trout, accessed 2021-06-18
+https://www.wikidata.org/wiki/Q5138345, accessed 2021-06-18</dc:source>
+    <owl:annotatedTarget>O. c. clarkii
+Onchorhynchus c. clarkii
+sea-run cutthroat trout
+blueback trout
+harvest trout</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000653"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A215">
+    <dc:source>https://www.monitoringresources.org/Document/Method/Details/1549, accessed 2021-06-14</dc:source>
+    <owl:annotatedTarget>A fish measurement method in which the length from the middle of the orbit (i.e. eye) to the hypural plate is recorded. Two common procedures are:
+
+(a) Using a measuring board: A fish is placed on its side on a measuring board with its snout against the rigid headpiece. A measurement is taken from the middle of the orbit (i.e. eye) to the hypural plate.
+
+(b) Using a tape measure: A fish is placed on its side, either on top of a tape measure or the tape measure is placed just above the dorsal side of the fish to record the measurement from the middle of the orbit (i.e. eye) to the hypural plate. It is important to not allow the tape to curve along the contoured side of the fish that is facing up, which can introduce bias into the measurement due to girth.
+
+In the case that hypural plate is not visible, the measurement may be made to some external feature (e.g. the position of the last lateral line scale; end of the fleshy caudal peduncle; midline of a crease that forms when the tail is bent sharply). It is important to note this adjustment in measurement protocol.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000633"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002439">
+    <rdfs:label xml:lang="en">creek name</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-15T23:46:34Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002768"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A216">
+    <dc:source>https://spo.nmfs.noaa.gov/sites/default/files/legacy-pdfs/leaflet488.pdf, accessed 2021-04-15</dc:source>
+    <owl:annotatedTarget>Circuli are more widely spaced in warmer months when food is abundant and growth is rapid, and more narrowly spaced in colder months when food availability is low and growth slows.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000235"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000820">
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000517"/>
+    <skos:broadMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000517"/>
+    <rdfs:label xml:lang="en">Kokanee salmon</rdfs:label>
+    <dc:description rdf:resource="https://en.wikipedia.org/wiki/Kokanee_salmon"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-03T22:40:10Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <j.1:SALMON_00000617 rdf:resource="http://purl.dataone.org/odo/SALMON_00000823"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000517">
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-30T17:45:49Z</dc:date>
+    <rdfs:label xml:lang="en">Sockeye salmon</rdfs:label>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <owl:sameAs rdf:resource="http://purl.dataone.org/odo/SALMON_00000803"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000242"/>
+    <j.2:scientificName rdf:resource="http://purl.dataone.org/odo/SALMON_00000511"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <j.1:SALMON_00000596 rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">420</j.1:SALMON_00000596>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000463"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000408">
+    <skos:definition>A standardized notation format for describing the age of a salmon.</skos:definition>
+    <rdfs:label xml:lang="en">Fish age notation type</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-22T00:00:42Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000478"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A217">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Atlantic_salmon, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q188879, accessed 2021-06-15</j.4:hasDbXref>
+    <owl:annotatedTarget>Salmo salar is the only species of Atlantic salmon.
+
+Physical Description: Atlantic salmon are the largest species in their genus, Salmo. After two years at sea, the fish average 71 to 76 cm (28 to 30 in) in length and 3.6 to 5.4 kg (7.9 to 11.9 lb) in weight. The colouration of young Atlantic salmon does not resemble the adult stage. While they live in fresh water, they have blue and red spots. At maturity, they take on a silver-blue sheen. The easiest way of identifying them as an adult is by the black spots predominantly above the lateral line, though the caudal fin is usually unspotted. When they reproduce, males take on a slight green or red colouration. The salmon has a fusiform body, and well-developed teeth. All fins, except the adipose fin, are bordered with black.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000590"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A218">
+    <dc:source>http://purl.obolibrary.org/obo/ENVO_00000138</dc:source>
+    <owl:annotatedTarget>A circular or round inlet with a narrow entrance.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000225"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A219">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Chinook_salmon, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q833503, accessed 2021-06-15</j.4:hasDbXref>
+    <owl:annotatedTarget>Oncorhynchus tshawytscha (i.e. Chinook salmon) is the largest of the five species of Pacific salmon.
+
+Physical Description: The Chinook is blue-green, red, or purple on the back and top of the head, with silvery sides and white ventral surfaces. It has black spots on its tail and the upper half of its body. Although spots are seen on the tail in pink salmon, and silver on the tail in coho and chum salmon, Chinook are unique among the Pacific salmon in combining black spots and silver on the tail. Another distinctive feature is a black gum line that is present in both salt and freshwater. Adult fish range in size from 24 to 36 in (61 to 91 cm), but may be up to 58 in (150 cm) in length; they average 10 to 50 lb (4.5 to 22.7 kg), but may reach 130 lb (59 kg). The meat can be either pink or white in color, depending on what the salmon have been feeding on.
+
+Range: Chinook are anadromous fish native to the North Pacific Ocean and the river systems of western North America, ranging from California to Alaska, as well as Asian rivers ranging from northern Japan to the Palyavaam River in the Arctic northeast Siberia. They have been introduced to other parts of the world, including New Zealand, thriving in Lake Michigan Great Lakes of North America and Michigan's western rivers, and Patagonia.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000464"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000759">
+    <skos:definition>Total number of recruits of age class 7.4.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 7.4 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T19:35:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000754"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000626">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/PCO_0000075</skos:exactMatch>
+    <skos:definition>A community species diversity that is the ratio between regional and local species diversity.</skos:definition>
+    <skos:altLabel>β-diversity</skos:altLabel>
+    <rdfs:label xml:lang="en">Beta diversity</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-04T22:00:59Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000624"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000735">
+    <skos:definition>Total number of recruits of age class 4.9.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 4.9 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:54:45Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000668"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A220">
+    <j.4:hasDbXref>https://www.researchgate.net/profile/Darlene-Gillespie/publication/281285926_Chinook_Salmon_Oncorhynchus_tshawytscha_Scale_Age_Determination_Procedures/links/55df66d708aede0b572b8de7/Chinook-Salmon-Oncorhynchus-tshawytscha-Scale-Age-Determination-Procedures.pdf, accessed 20212-04-09
+
+https://www.pac.dfo-mpo.gc.ca/fm-gp/fraser/docs/abor-autoc/2010FrasRvrChkInformDoc.htm, accessed 20212-04-09</j.4:hasDbXref>
+    <owl:annotatedTarget>e.g. An age written in Gilbert-Rich notation as '5sub2' (spoken as "five sub two") is interpreted as a fish that is in its fifth year of life (i.e. a fish that will be 5 on its next "birthday" or the number of winters from its deposition in the gravel as an egg to the time of sampling) and which migrated to the ocean during its second year of life. The European notation equivalent age is written as '1.3'.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000201"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000602">
+    <rdfs:label xml:lang="en">Dolly Varden trout</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-27T19:58:43Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:SALMON_00000596 rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">531</j.1:SALMON_00000596>
+    <j.2:scientificName rdf:resource="http://purl.dataone.org/odo/SALMON_00000600"/>
+    <j.1:SALMON_00000617 rdf:resource="http://purl.dataone.org/odo/SALMON_00000650"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000126"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000711">
+    <skos:definition>Total number of recruits of age class 2.3.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 2.3 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:50:00Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000666"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A221">
+    <dc:source>https://en.wikipedia.org/wiki/Oncorhynchus, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q133325, accessed 2021-06-15</dc:source>
+    <owl:annotatedTarget>Oncorhynchus is a genus of fish in the family Salmonidae; it contains the Pacific salmon and Pacific trout. The name of the genus is derived from the Greek ὄγκος (ónkos, “lump, bend”) + ῥύγχος (rhúnkhos, “snout”), in reference to the hooked jaws of males in the mating season (the "kype").</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000587"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A222">
+    <rdfs:comment>"MEHL" is an acronym used by Alaska Department of Fish &amp; Game (ADF&amp;G)</rdfs:comment>
+    <owl:annotatedTarget>Mid-eye to hypural plate
+MEHL
+MEPS
+Mid-eye to posterior scale</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000131"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A223">
+    <j.4:hasDbXref>https://www.monitoringresources.org/Document/Method/Details/1548, accessed 2021-03-31
+https://www.monitoringresources.org/Document/Method/Details/4041, accessed 2021-03-31</j.4:hasDbXref>
+    <owl:annotatedTarget>A fish length measurement taken from the hind margin of the orbit to the tip of the median caudal fin rays.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000129"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A224">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Fish_wheel, accessed 2021-04-01
+https://www.wikidata.org/wiki/Q5454688, accessed 2021-04-01</j.4:hasDbXref>
+    <owl:annotatedTarget>A device which (a) is situated in rivers for catching fish, and (b) looks and operates like a watermill that is outfitted with wire baskets designed to catch and carry fish from the water and into a nearby holding tank.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000145"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A117">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000678"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000710">
+    <skos:definition>Total number of recruits of age class 2.2.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 2.2 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:49:54Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000666"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A225">
+    <dc:source>http://purl.obolibrary.org/obo/ENVO_00000039</dc:source>
+    <owl:annotatedTarget>A long and narrow sea inlet with high steeply sloped walled sides. A fjord is a landform created during a period of glaciation.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000227"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000516">
+    <rdfs:label xml:lang="en">Pink salmon</rdfs:label>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:SALMON_00000596 rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">440</j.1:SALMON_00000596>
+    <j.2:scientificName rdf:resource="http://purl.dataone.org/odo/SALMON_00000508"/>
+    <owl:sameAs rdf:resource="http://purl.dataone.org/odo/SALMON_00000800"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000460"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000241"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A7">
+    <rdf:rest rdf:nodeID="A45"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000241"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000407">
+    <skos:definition>Elapsed time, typically expressed in years, (a) since birth or (b) which describes the how long a salmon has spent in a particular environment (e.g. saltwater vs. freshwater).</skos:definition>
+    <rdfs:label xml:lang="en">Numeric age of fish</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-22T00:00:18Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000184"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A226">
+    <rdfs:comment>Indigenous names for salmon can be found by exploring each SASAP region's page on the State of Alaska's Salmon and People website (for example, see the Arctic Region here: https://alaskasalmonandpeople.org/region/arctic/)</rdfs:comment>
+    <dc:source>https://alaskasalmonandpeople.org/regions/, accessed 2021-04-16</dc:source>
+    <owl:annotatedTarget>"Saanlaaghe" [Denaakk'e, Koyukon Athabaskan]
+"Khwyhts'en'" [Benhti Kenaga, Lower Tanana]
+"Shii" @gwi
+"Caayuryaq" @ypk
+"Qakiiyaq" @ypk
+"Qavlunaq" @ypk
+"Uqurliq" @ypk
+"Qakiidax̂: @ale [Unangam tunuu variant]
+"Qakiiyaq" [Alutiiq/Sugpiaq]
+"ta'ay" @eyk
+"ÜÜx" @tsi @tli
+"L'ook" @tsi @tli</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000243"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A227">
+    <dc:source>http://purl.dataone.org/odo/ECSO_00001164</dc:source>
+    <owl:annotatedTarget>A measure of the saltiness or dissolved salt content of a body of water.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000416"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000649">
+    <skos:definition>A young salmonid (salmon or trout) with parr-marks before migration to the sea and after dispersal from the redd.</skos:definition>
+    <rdfs:label xml:lang="en">Parr</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-16T04:18:20Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000401"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A228">
+    <dc:source>https://en.wikipedia.org/wiki/Longitude</dc:source>
+    <owl:annotatedTarget>Longitude (/ˈlɒndʒɪtjuːd/, AU and UK also /ˈlɒŋɡɪ-/)[1][2] is a geographic coordinate that specifies the east–west position of a point on the Earth's surface, or the surface of a celestial body. It is an angular measurement, usually expressed in degrees and denoted by the Greek letter lambda (λ). Meridians (lines running from pole to pole) connect points with the same longitude. The prime meridian, which passes near the Royal Observatory, Greenwich, England, is defined as 0° longitude by convention. Positive longitudes are east of the prime meridian, and negative ones are west.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/ECSO_00002132"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000758">
+    <skos:definition>Total number of recruits of age class 7.3.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 7.3 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T19:35:00Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000754"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000625">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/PCO_0000074</skos:exactMatch>
+    <skos:definition>A community species diversity that is the mean species diversity at a site or within a specific habitat.</skos:definition>
+    <skos:altLabel>α-diversity</skos:altLabel>
+    <rdfs:label xml:lang="en">Alpha diversity</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-04T22:00:56Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000624"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000734">
+    <skos:definition>Total number of recruits of age class 4.8.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 4.8 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:54:40Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000668"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000601">
+    <rdfs:label xml:lang="en">Atlantic salmon</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-27T19:58:37Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.2:scientificName rdf:resource="http://purl.dataone.org/odo/SALMON_00000599"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000586"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A229">
+    <dc:source>http://orcid.org/0000-0002-5300-3075</dc:source>
+    <owl:annotatedTarget>Equipment which is used to harvest aquatic resources, and in particular fish(es).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000142"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A230">
+    <dc:source>https://en.wikipedia.org/wiki/Body_of_water, accessed 2021-03-30</dc:source>
+    <owl:annotatedTarget>The term body of water most often refers to large accumulations of water, such as oceans, seas, and lakes, but it includes smaller pools of water such as ponds, wetlands, or more rarely, puddles. A body of water does not have to be still or contained; Rivers, streams, canals, and other geographical features where water moves from one place to another are also considered bodies of water.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000125"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A231">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>The number of salmon which survive to reach legal age and/or size for harvest. Recruits include both individuals that are captured by a fishery and individuals that escape the fishery -- total recruitment is calculated as catch plus escapement.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000663"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000600">
+    <rdfs:label xml:lang="en">Salvelinus malma</rdfs:label>
+    <rdfs:comment>Some Dolly Varden individuals are anadromous</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-27T19:45:59Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.2:vernacularName rdf:resource="http://purl.dataone.org/odo/SALMON_00000602"/>
+    <j.2:nameAccordingTo rdf:resource="http://purl.dataone.org/odo/SALMON_00000475"/>
+    <j.1:SALMON_00000618 rdf:resource="http://purl.dataone.org/odo/SALMON_00000612"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000592"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A232">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>If performed correctly, this type of identification can remain in place for at least a year, is used for individual tagging, and is suitable for fish at lest 20cm in length and which live in open environments. With the cannula attached to a special tag applicator, a scale is removed just below the base of the dorsal fin and the tag is attached. The barb on the tag must hook securely into the pterygiophores (the bones that supports the dorsal fin), otherwise the tag will come loose. Most of the tag then hangs outside the fish’s body like a stiff, narrow tube. The tag is colour-coded, pre-printed with relevant text and numbered by the manufacturer according to the requests of the end user.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000549"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000842">
+    <rdfs:label xml:lang="en">has scientific name</rdfs:label>
+    <owl:equivalentProperty rdf:resource="http://rs.tdwg.org/dwc/terms/scientificName"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000515">
+    <rdfs:label xml:lang="en">Coho salmon</rdfs:label>
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000802"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <owl:sameAs rdf:resource="http://purl.dataone.org/odo/SALMON_00000802"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000462"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-30T17:45:43Z</dc:date>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000243"/>
+    <j.2:scientificName rdf:resource="http://purl.dataone.org/odo/SALMON_00000510"/>
+    <j.1:SALMON_00000596 rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">430</j.1:SALMON_00000596>
+    <j.2:nameAccordingTo rdf:resource="http://purl.dataone.org/odo/SALMON_00000475"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000406">
+    <skos:definition>Fish that have fully developed morphological and meristic characters and that have attained sexual maturity.</skos:definition>
+    <rdfs:label xml:lang="en">Adult</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T23:42:40Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000401"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002768">
+    <rdfs:label xml:lang="en">study location name</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-04-24T00:15:35Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000878"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000539">
+    <skos:definition>Tag based on application of chemical agents used to enhance the color or contrast of target materials or samples. Dyes have some affinity for their substrates and are usually applied in a solution.</skos:definition>
+    <rdfs:label xml:lang="en">Dye tag</rdfs:label>
+    <rdfs:comment>[NEEDS ALIGHMENT]
+
+http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C461</rdfs:comment>
+    <rdfs:comment>The URI http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C461 does not resolve to the term. Including the URL to BioPortal to ensure findability: https://bioportal.bioontology.org/ontologies/NCIT?p=classes&amp;conceptid=http%3A%2F%2Fncicb.nci.nih.gov%2Fxml%2Fowl%2FEVS%2FThesaurus.owl%23C461</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:26:27Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000530"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A233">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Rainbow_trout, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q187986, accessed 2021-06-15</j.4:hasDbXref>
+    <owl:annotatedTarget>Oncorhynchus mykiss (i.e. rainbow trout) is a species of Pacific trout.
+
+Physical Description: Resident freshwater rainbow trout adults average between 1 and 5 lb (0.5 and 2.3 kg) in riverine environments, while lake-dwelling and anadromous forms may reach 20 lb (9 kg). Coloration varies widely between regions and subspecies. Adult freshwater forms are generally blue-green or olive green with heavy black spotting over the length of the body. Adult fish have a broad reddish stripe along the lateral line, from gills to the tail, which is most pronounced in breeding males. The caudal fin is squarish and only mildly forked. Lake-dwelling and anadromous forms are usually more silvery in color with the reddish stripe almost completely gone. Juvenile rainbow trout display parr marks (dark vertical bars) typical of most salmonid juveniles. In some redband and golden trout forms parr marks are typically retained into adulthood. Some coastal rainbow trout (O. m. irideus) and Columbia River redband trout (O. m. gairdneri) populations and cutbow hybrids may also display reddish or pink throat markings similar to cutthroat trout. In many regions, hatchery-bred trout can be distinguished from native trout via fin clips. Fin clipping the adipose fin is a management tool used to identify hatchery-reared fish.
+
+Range: The native range of Oncorhynchus mykiss is in the coastal waters and tributary streams of the Pacific basin, from the Kamchatka Peninsula in Russia, east along the Aleutian Islands, throughout southwest Alaska, the Pacific coast of British Columbia and southeast Alaska, and south along the west coast of the U.S. to northern Mexico. It is claimed that the Mexican forms of Oncorhynchus mykiss represent the southernmost native range of any trout or salmon (Salmonidae), though the Formosan landlocked salmon (O. masou formosanus) in Asia inhabits a similar latitude. The range of coastal rainbow trout (O. m. irideus) extends north from the Pacific basin into tributaries of the Bering Sea in northwest Alaska, while forms of the Columbia River redband trout (O. m. gairdneri) extend east into the upper Mackenzie River and Peace River watersheds in British Columbia and Alberta, Canada, which eventually drain into the Beaufort Sea, part of the Arctic Ocean. Since 1875, the rainbow trout has been widely introduced into suitable lacustrine and riverine environments throughout the United States and around the world. Many of these introductions have established wild, self-sustaining populations.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000591"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A234">
+    <dc:source>https://spo.nmfs.noaa.gov/sites/default/files/legacy-pdfs/leaflet488.pdf, accessed 2021-04-15</dc:source>
+    <owl:annotatedTarget>The measured distance between the fine ridges of a scale (i.e. circuli) which are laid down annually in a circular pattern around the focus, or center, of a scale as the growth of the fish proceeds.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000235"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000648">
+    <j.2:scientificName rdf:resource="http://purl.dataone.org/odo/SALMON_00000647"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000126"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-15T23:43:41Z</dc:date>
+    <rdfs:label xml:lang="en">Coastal rainbow trout</rdfs:label>
+    <skos:broadMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000643"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000644"/>
+    <j.1:SALMON_00000617 rdf:resource="http://purl.dataone.org/odo/SALMON_00000650"/>
+    <skos:narrowMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000570"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000757">
+    <skos:definition>Total number of recruits of age class 7.2.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 7.2 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T19:34:51Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000754"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A235">
+    <dc:source>http://purl.obolibrary.org/obo/ENVO_00002297 [DEPRECATED]</dc:source>
+    <owl:annotatedTarget>A material entity which determines an environmental system.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000202"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000624">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/PCO_0000019</skos:exactMatch>
+    <skos:definition>The number of different species that are represented in a given community, weighted by their abundance. Community species diversity can be calculated in different ways, but consists of two components: species richness and species evenness.</skos:definition>
+    <rdfs:label xml:lang="en">Species diversity</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-04T22:00:50Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000503"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000733">
+    <skos:definition>Total number of recruits of age class 4.7.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 4.7 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:54:35Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000668"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A236">
+    <dc:source>http://purl.obolibrary.org/obo/ENVO_01000618</dc:source>
+    <owl:annotatedTarget>A water body in which the accumulated water, in its totality, is flowing.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000196"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A237">
+    <dc:source>https://www.monitoringresources.org/Document/Method/Details/1551, accessed 2021-03-31</dc:source>
+    <owl:annotatedTarget>A fish length measurement of the entire length of a fish's body, taken from the most anterior part of the fish to the tip of the longest caudal fin rays.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000134"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A238">
+    <dc:source>https://en.wikipedia.org/wiki/Semelparity_and_iteroparity#Semelparity, accessed 01June2021
+https://www.wikidata.org/wiki/Q522960, accessed 01June2021</dc:source>
+    <owl:annotatedTarget>A reproductive strategy which is characterized by multiple reproductive cycles over the course of an organism's lifetime.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000612"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000841">
+    <rdfs:label xml:lang="en">has vernacular name</rdfs:label>
+    <owl:equivalentProperty rdf:resource="http://rs.tdwg.org/dwc/terms/vernacularName"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000732">
+    <skos:definition>Total number of recruits of age class 4.6.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 4.6 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:54:29Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000668"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000514">
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000240"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-30T17:45:41Z</dc:date>
+    <j.2:scientificName rdf:resource="http://purl.dataone.org/odo/SALMON_00000509"/>
+    <j.1:SALMON_00000596 rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">450</j.1:SALMON_00000596>
+    <owl:sameAs rdf:resource="http://purl.dataone.org/odo/SALMON_00000801"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000461"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:label xml:lang="en">Chum salmon</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000405">
+    <skos:definition>A young fish at the post-larval stage. May include all fish stages from hatching to fingerling. An advanced fry is any young fish from the start of exogenous feeding after the yolk is absorbed while a sac fry is from hatching to yolk sac absorption. In Salmonidae the stage from end of dependence on the yolk sac as the primary source of nutrition to dispersal from the redd.</skos:definition>
+    <rdfs:label xml:lang="en">Fry</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T23:42:38Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000401"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000538">
+    <skos:definition>A scar made on the dermal tissue using liquid nitrogen.</skos:definition>
+    <rdfs:label xml:lang="en">Freeze brand</rdfs:label>
+    <dc:description>This identification type may be clearly visible for several months and can be felt for up to a year, is primarily used for group marking, and is most suitable for salmonids that are at least 7.5cm in length. Freeze branding is done by cooling a metal rod and/or brand in liquid nitrogen, then pressing the rod lightly against the fish for ~3sec. A dark spot is temporarily created and the fish's scales are deformed. The dark spot disappears after about a month, while the deformation of the scales can be seen at certain light angles and felt with fingers for up to a year.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:25:55Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000557"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A239">
+    <rdfs:comment>Indigenous names for salmon can be found by exploring each SASAP region's page on the State of Alaska's Salmon and People website (for example, see the Arctic Region here: https://alaskasalmonandpeople.org/region/arctic/)</rdfs:comment>
+    <dc:source>https://alaskasalmonandpeople.org/regions/, accessed 2021-04-16</dc:source>
+    <owl:annotatedTarget>"Amaqtuq" @ipk
+"Amaqaayak" @ypk
+"Amaqsuq" @ypk
+"Cuqpeq" @ypk
+"Terteq" @ypk
+"Qungaayux" @ale [Unangam tunuu variant]
+"Amartuq" [Alutiiq/Sugpiaq]
+"Amaqaayak" [Alutiiq/Sugpiaq]
+"Dak'aay" [Ahtna]
+"Dak'aagi" [Ahtna]
+"qughuna" [Kenai Dena'ina]
+"giyah sdilahL" @eyk
+"kaashk'" @eyk
+"Sti'moon" @tsi @tli
+"Cháas'" @tsi @tli</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000241"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A240">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>This type of identification can remain on a fish for several years, is used for individual tagging, and is most suitable for fish that weigh at least 100g (given current technology). One or more sutures are typically used to attach the tag to the fish's skin using a needle. Data is transmitted wirelessly, usually through the use of radio waves (in fresh water and air), acoustic signals (in water; the receiver must also be in the water) or via satellite communication (in air; the tag sends data after it releases from the fish and floats up to the surface). Many types of telemetry devices also act as bio-loggers and store information locally on the device. Reading is done using the tag’s associated equipment, often through a computer connection.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000546"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000647">
+    <j.2:vernacularName rdf:resource="http://purl.dataone.org/odo/SALMON_00000648"/>
+    <skos:closeMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000643"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000644"/>
+    <rdfs:comment>Sea-running, i.e. anadromous individuals of Rainbow Trout are called Steelhead.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:label xml:lang="en">Oncorhynchus mykiss irideus</rdfs:label>
+    <j.2:nameAccordingTo rdf:resource="http://purl.dataone.org/odo/SALMON_00000646"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-15T23:34:02Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000587"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000756">
+    <skos:definition>Total number of recruits of age class 7.1.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 7.1 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T19:34:44Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000754"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000623">
+    <skos:exactMatch>http://purl.dataone.org/odo/ECSO_00001237</skos:exactMatch>
+    <skos:definition>Volume of precipitation, which is any product of the condensation of atmospheric water vapor that falls under gravity.</skos:definition>
+    <rdfs:label xml:lang="en">Precipitation volume</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-04T21:13:21Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000220"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000513">
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:SALMON_00000596 rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">410</j.1:SALMON_00000596>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000239"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-30T17:45:38Z</dc:date>
+    <j.2:scientificName rdf:resource="http://purl.dataone.org/odo/SALMON_00000512"/>
+    <owl:sameAs rdf:resource="http://purl.dataone.org/odo/SALMON_00000804"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:label xml:lang="en">Chinook salmon</rdfs:label>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000464"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000622">
+    <rdfs:label xml:lang="en">Egg abundance</rdfs:label>
+    <rdfs:comment>An Essential Salmon Variable (ESV) from the working list being developed by Graeme Diack et al. at the Atlantic Salmon Trust.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-01T22:28:19Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000504"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000404">
+    <skos:definition>1) A young salmonid which has developed silvery coloring on its sides, obscuring the parr marks, and which is about to migrate or has just migrated into the sea, 2) to undergo the transformation from parr to smolt.</skos:definition>
+    <rdfs:label xml:lang="en">Smolt</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T23:42:21Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000401"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A241">
+    <dc:source>https://en.wikipedia.org/wiki/John_Richardson_(naturalist), accessed 2021-06-15
+https://www.wikidata.org/wiki/Q545944, accessed 2021-06-15</dc:source>
+    <owl:annotatedTarget>Sir John Richardson (5 ovember 1787 - 5 June 1865) was a Scottish naval surgeon, naturalist and arctic explorer.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000595"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000731">
+    <skos:definition>Total number of recruits of age class 4.5.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 4.5 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:54:24Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000668"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000537">
+    <skos:definition>Tag based on application of a dilution of fluorochrome dye in which fish are immersed and which binds to bony structures (such as fin rays, jaw bones, and scales), manifesting as a green fluorescence.</skos:definition>
+    <skos:altLabel>SE-MARK</skos:altLabel>
+    <rdfs:label xml:lang="en">Calcein dye tag</rdfs:label>
+    <dc:description>Though not well studied, this type of identification may last up to 3 years post-immersion, and is used for group marking.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:24:43Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000539"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000840">
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000461"/>
+    <rdfs:label xml:lang="en">Dog salmon</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000779">
+    <skos:definition>A method which is used to approximate the total weight of a fish and which involves wrapping a cloth tape measure perpendicular to the longitudinal axis of the fish to measure its circumference at the thickest point.</skos:definition>
+    <rdfs:label xml:lang="en">Measuring the girth of a fish</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-16T19:37:41Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000778"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A23">
+    <rdf:rest rdf:nodeID="A125"/>
+    <rdf:first rdf:nodeID="A18"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000646">
+    <rdfs:label xml:lang="en">Gibbons, 1855</rdfs:label>
+    <dc:description>In 1855, William P. Gibbons, the curator of Geology and Mineralogy at the California Academy of Sciences, found a population and named it Salmo iridia (Latin: rainbow), later corrected to Salmo irideus. These names faded once it was determined that Walbaum's description of type specimens was conspecific and therefore had precedence. In 1989, morphological and genetic studies indicated that trout of the Pacific Basin were genetically closer to Pacific salmon (Oncorhynchus species) than to the Salmos – brown trout (Salmo trutta) or Atlantic salmon (Salmo salar) of the Atlantic Basin. Thus, in 1989, taxonomic authorities moved the rainbow, cutthroat, and other Pacific Basin trout into the genus Oncorhynchus. Walbaum's name had precedence, so the species name Oncorhynchus mykiss became the scientific name of the rainbow trout. The previous species names irideus and gairdneri were adopted as subspecies names for the coastal rainbow and Columbia River redband trout, respectively.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-15T23:33:16Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000495"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000755">
+    <rdfs:label>Age class 8.x recruits</rdfs:label>
+    <dc:description>Total number of recruits of age class 8</dc:description>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000855"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A242">
+    <dc:source rdf:resource="https://www.wikidata.org/wiki/Q673380"/>
+    <dc:source rdf:resource="https://en.wikipedia.org/wiki/Pink_salmon"/>
+    <owl:annotatedTarget>Oncorhynchus gorbuscha
+O. gorbuscha
+"humpback salmon" @en
+"humpbacked salmon" @en</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000241"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A243">
+    <dc:source>https://www.monitoringresources.org/Document/Method/Details/1548, accessed 2021-03-31</dc:source>
+    <owl:annotatedTarget>A fish length measurement taken from the hind margin of the orbit to the hypural plate.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000130"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A244">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>The weight of a fish, typically taken when the specimen is still alive or freshly deceased, but before being frozen or further processed.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000659"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A245">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>An identifier, which may be assigned to a physical sample taken from a fish (e.g. tissue, fin, otolith) or an entire fish specimen.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000529"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A246">
+    <dc:source>https://www.solitudelakemanagement.com/blog/know-your-pond-life-fin-clipping-for-fisheries-management-success/, accessed 2021-05-05</dc:source>
+    <owl:annotatedTarget>A portion of the upper caudal fin lobe is removed.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000542"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000403">
+    <skos:definition>Larval salmon that have hatched but have not yet completely absorbed their yolk sacs and usually have not yet emerged from the gravel.</skos:definition>
+    <rdfs:label xml:lang="en">Alevin</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T23:42:13Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000401"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000754">
+    <rdfs:label>Age class 7.x recruits</rdfs:label>
+    <dc:identifier>Total number of recruits of age class 7</dc:identifier>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000855"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000536">
+    <skos:definition>Tag based on application of a dilution of diazo dye in which fish are immersed and which stains the fins a brown/tan color.</skos:definition>
+    <skos:altLabel>Bismarck brown
+Machester brown
+Phenylene brown
+Bismarck brown Y
+C.I. 21000
+C.I. Basic Brown 1
+Basic Brown 1
+Vesuvine BA</skos:altLabel>
+    <rdfs:label xml:lang="en">Bismarck brown dye tag</rdfs:label>
+    <dc:description>This type of identification can remain on a fish from a couple days up to several weeks, and is used for group marking. and is most suitable for fish</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:23:36Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000539"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000621">
+    <rdfs:label xml:lang="en">Smolt abundance</rdfs:label>
+    <rdfs:comment>An Essential Salmon Variable (ESV) from the working list being developed by Graeme Diack et al. at the Atlantic Salmon Trust.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-01T22:27:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000504"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000730">
+    <skos:definition>Total number of recruits of age class 4.4.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 4.4 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:54:20Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000668"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A247">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>A standardized notation format for describing the age of a salmon.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000408"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000669">
+    <skos:definition>Total number of recruits of age class five.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 5.x recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-17T16:31:10Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000855"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A248">
+    <dc:source>https://www.monitoringresources.org/Document/Method/Details/1549, accessed 2021-06-14</dc:source>
+    <owl:annotatedTarget>Measurements of specific parts of a fish are sometimes necessary when intact fish are not available. For instance, spawning or dead salmon often have eroded tails (from redd excavation) or enlarged or damaged jaws. When researchers want to compare fish lengths of male spawners versus female spawners or hatchery spawned females versus carcasses, it is a good idea to use this type of length measurement to remove the bias of the eroded tails on female spawners. So length measurements are made from specific parts of the body that are intact, such as the orbit and the hypural plate. The hypural plate is comprised of modified vertebrae that support the rays of the caudal fin and originate from the posterior end of the vertebral column. This measurement is also commonly referred to as MEPS, or mid-eye to posterior scale, noting that researchers typically take the measurement to an external feature when the hypural plate is not visible.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000633"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000778">
+    <rdfs:label xml:lang="en">Fish weight determination method</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-16T19:37:18Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000182"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000512">
+    <j.2:vernacularName rdf:resource="http://purl.dataone.org/odo/SALMON_00000513"/>
+    <j.2:vernacularName rdf:resource="http://purl.dataone.org/odo/SALMON_00000804"/>
+    <j.2:nameAccordingTo rdf:resource="http://purl.dataone.org/odo/SALMON_00000475"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-30T17:45:30Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:label xml:lang="en">Oncorhynchus tshawytscha</rdfs:label>
+    <j.1:SALMON_00000617 rdf:resource="http://purl.dataone.org/odo/SALMON_00000615"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000464"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000587"/>
+    <j.1:SALMON_00000618 rdf:resource="http://purl.dataone.org/odo/SALMON_00000613"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000645">
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000642"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00001720">
+    <rdfs:label xml:lang="en">data quality flag</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-11-30T05:06:08Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00001719"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A249">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Temperature, accessed 2021-04-22
+https://www.wikidata.org/wiki/Q11466, accessed 2021-04-22</j.4:hasDbXref>
+    <owl:annotatedTarget>The objective measure of hot or cold in freshwater (i.e. non-saline water).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000411"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A250">
+    <dc:source>https://www.researchgate.net/profile/Darlene-Gillespie/publication/281285926_Chinook_Salmon_Oncorhynchus_tshawytscha_Scale_Age_Determination_Procedures/links/55df66d708aede0b572b8de7/Chinook-Salmon-Oncorhynchus-tshawytscha-Scale-Age-Determination-Procedures.pdf, accessed 20212-04-09</dc:source>
+    <owl:annotatedTarget>e.g. An age written in European notation as '1.3' is interpreted as 1 year over-wintered in freshwater and 3 years in the ocean. The total age is 4 years (1 + 3 years). The Gilbert-Rich equivalent age is written as '5sub2'.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000200"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000535">
+    <skos:definition>The adipose fin is removed using scissors or a razor blade.</skos:definition>
+    <rdfs:label xml:lang="en">Adipose fin clip</rdfs:label>
+    <dc:description>When done correctly, this identification type will last the entire life of the fish, and is used for group marking.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T16:20:22Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000540"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000644">
+    <rdfs:label>Oncorhynchus mykiss irideus</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000591"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000753">
+    <skos:definition>Total number of recruits of age class 6.9.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 6.9 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:58:29Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000670"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000426">
+    <skos:definition>A concentration of the amount of oxygen present in water.</skos:definition>
+    <skos:altLabel>DO concentration</skos:altLabel>
+    <rdfs:label xml:lang="en">Dissolved oxygen concentration</rdfs:label>
+    <rdfs:comment>http://purl.dataone.org/odo/ECSO_00001669</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-22T18:13:32Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000424"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000620">
+    <rdfs:label xml:lang="en">migratoryPatternOf</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-01T20:31:46Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:domain rdf:resource="http://purl.dataone.org/odo/SALMON_00000614"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A251">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Trolling_(fishing), accessed 2021-04-01</j.4:hasDbXref>
+    <owl:annotatedTarget>One or more fishing lines, which are baited with lures or bait fish and drawn through the water (often behind a moving vessel) to catch pelagic fishes.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000155"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000559">
+    <rdfs:label xml:lang="en">Subcutaneous tag</rdfs:label>
+    <dc:description>A mark or tag which is placed beneath the skin of a fish.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-05T23:07:11Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000530"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002061">
+    <skos:altLabel>Julian day fractional</skos:altLabel>
+    <rdfs:label xml:lang="en">fractional day of year</rdfs:label>
+    <j.4:hasExactSynonym>Julian day fractional</j.4:hasExactSynonym>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-15T18:52:39Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002058"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000668">
+    <skos:definition>Total number of recruits of age class four.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 4.x recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-17T16:31:03Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000855"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000511">
+    <j.2:vernacularName rdf:resource="http://purl.dataone.org/odo/SALMON_00000803"/>
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000803"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000517"/>
+    <j.1:SALMON_00000617 rdf:resource="http://purl.dataone.org/odo/SALMON_00000615"/>
+    <j.2:vernacularName rdf:resource="http://purl.dataone.org/odo/SALMON_00000517"/>
+    <rdfs:label xml:lang="en">Oncorhynchus nerka</rdfs:label>
+    <j.2:nameAccordingTo rdf:resource="http://purl.dataone.org/odo/SALMON_00000475"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000463"/>
+    <owl:sameAs rdf:resource="http://purl.dataone.org/odo/SALMON_00000803"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000587"/>
+    <j.1:SALMON_00000618 rdf:resource="http://purl.dataone.org/odo/SALMON_00000613"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-30T17:45:08Z</dc:date>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000402">
+    <skos:definition>In fish, the term egg usually refers to female haploid gametes.</skos:definition>
+    <rdfs:label xml:lang="en">Egg</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T23:42:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000401"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000777">
+    <skos:definition>A measurement taken around the thickest portion of the midsection of a fish.</skos:definition>
+    <rdfs:label xml:lang="en">Girth of fish</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-16T19:32:26Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000776"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A252">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>The number of sea lice counted on an individual fish.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000688"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000829">
+    <rdfs:label xml:lang="en">Organism name or identifier</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-12T17:29:30Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000492">
+    <rdfs:label xml:lang="en">Commercial harvest count</rdfs:label>
+    <rdfs:comment>Estimates of number of fish caught based on some commerical harvest</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-28T18:15:54Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000491"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000250">
+    <rdfs:label xml:lang="en">Unknown sex</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-19T18:26:55Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000216"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002238">
+    <rdfs:label xml:lang="en">minutes elapsed</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-05-04T00:30:14Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002068"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A253">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>A static tag, which is attached externally to the body of the fish and visually read or interpreted (as opposed to read with an electronic device e.g. an acoustic tag reader).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000547"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A254">
+    <j.4:hasDbXref>https://www.fishbase.in/glossary/Glossary.php?q=standard+length, accessed 2021-03-31</j.4:hasDbXref>
+    <owl:annotatedTarget>A fish measurement method in which the length from the most anterior tip of the body to the midlateral posterior edge of the hypural plate (in fish with a hypural plate) or to the posterior end of the vertebral column (in fish lacking hypural plates) is recorded. Two common procedures are:
+
+(a) Using a measuring board: A fish is placed on its side on a measuring board with its snout against the rigid headpiece. A measurement is taken from the most anterior tip of the body to the midlateral posterior edge of the hypural plate (in fish with a hypural plate) or to the posterior end of the vertebral column (in fish lacking hypural plates).
+
+(b) Using a tape measure: A fish is placed on its side, either on top of a tape measure or the tape measure is placed just above the dorsal side of the fish to record the measurement from the most anterior tip of the body to the midlateral posterior edge of the hypural plate (in fish with a hypural plate) or to the posterior end of the vertebral column (in fish lacking hypural plates). It is important to not allow the tape to curve along the contoured side of the fish that is facing up, which can introduce bias into the measurement due to girth.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000637"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000805">
+    <rdfs:label xml:lang="en">Jack</rdfs:label>
+    <dc:description>Jacks are precocial male salmon that have spent one winter less in the ocean than the youngest females of a given species. Because they are younger, jack salmon are smaller than other age classes of conspecifics. Coho jacks return to spawn the same year they smolted and so are particularly small. Jack coloration can differ from that of older adults. Jacks are able to successfully sneak-spawn in spite of efforts by the female and occasionally the other males.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-22T02:55:24Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000401"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A255">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 05May2021</j.4:hasDbXref>
+    <owl:annotatedTarget>This identification type may last for several years or up to the lifetime of a fish, and is used for individual tagging. The tag is placed in the abdominal cavity or in the muscular tissue. Reading PIT tags can be done (a) automatically by detecting fish as they swim past (this is usually done by building an obstacle so that fish must pass close to the reader), or (b) manually by taking the fish up in the air to be scanned with a reader.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000551"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A256">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Hand_net, accessed 2021-04-01
+https://www.wikidata.org/wiki/Q640082, accessed 2021-04-01</j.4:hasDbXref>
+    <owl:annotatedTarget>A net or mesh basket held open by a hoop which may or may not be on the end of a handle and is used for scopping fish near the surface of the water.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000152"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000142">
+    <rdfs:label xml:lang="en">Fishing gear type</rdfs:label>
+    <rdfs:comment>[ADDRESS THIS COMMENT, THEN DELETE]
+
+Could use some input on subclass hierarchy. E.g. 'Hand collection' includes methods which are largely done with tools that can be operated by hand. 'Netting' includes things like gillnets and seines, which, while largely set from fishing vessels (particularly in commercial fisheries), can also be set by hand at smaller scales.</rdfs:comment>
+    <dc:description>Equipment which is used to harvest aquatic resources, and in particular fish(es).</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T18:00:22Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A257">
+    <dc:source rdf:resource="https://www.adfg.alaska.gov/static/license/fishing/pdfs/coar_fish_codes.pdf"/>
+    <owl:annotatedTarget>Alaska Department of Fish and Game (ADF&amp;G) uses a list of numeric codes to describe (a) commercially-harvested aquatic species, (b) gear used for harvest, (c) method of catch processing, and (d) delivery form and product type.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000596"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A258">
+    <dc:source>https://en.wikipedia.org/wiki/Rainbow_trout, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q187986, accessed 2021-06-15</dc:source>
+    <owl:annotatedTarget>Oncorhychus mykiss
+O. mykiss
+"lake trout" @en
+"rainbow" @en
+"silver trout" @en
+"steelhead" @en
+"brook trout" @en</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000642"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A35">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000594"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000491">
+    <skos:definition>The number of recruits which survive to a legal age and/or size and are captured by a fishery.</skos:definition>
+    <rdfs:label xml:lang="en">Salmon harvest count</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-28T18:15:41Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000504"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000719">
+    <skos:definition>Total number of recruits of age class 3.2.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 3.2 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:52:05Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000667"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A259">
+    <rdf:rest rdf:nodeID="A101"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000463"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A260">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Stream, accessed 2021-04-07
+https://www.wikidata.org/wiki/Q47521, accessed 2021-04-07</j.4:hasDbXref>
+    <dc:source>http://purl.obolibrary.org/obo/ENVO_00000023</dc:source>
+    <owl:annotatedTarget>A watercourse which is linear and flows across the solid portion of a planetary surface.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000194"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000828">
+    <rdfs:label xml:lang="en">contains occurrence data about</rdfs:label>
+    <rdfs:comment>Object property to enable linking an information-bearing object such as a dataset, to its assertion of some organismal occurrence (sensu Darwin Core)</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-12T01:42:16Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdfs:range rdf:resource="http://purl.dataone.org/odo/SALMON_00000829"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000189">
+    <skos:definition>The number of years or winters a salmon spends in a saltwater environment.</skos:definition>
+    <rdfs:label xml:lang="en">Saltwater age</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-06T23:14:20Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000407"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000804">
+    <rdfs:label xml:lang="en">King salmon</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-21T23:27:40Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000464"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000119">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000163">
+    <rdfs:label xml:lang="en">Netting</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T18:46:07Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000142"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://rs.tdwg.org/dwc/terms/nameAccordingTo">
+    <skos:definition>The reference to the source in which the specific taxon concept circumscription is defined or implied - traditionally signified by the Latin "sensu" or "sec." (from secundum, meaning "according to"). For taxa that result from identifications, a reference to the keys, monographs, experts and other sources should be given.</skos:definition>
+    <rdfs:comment>As of 30April2021, Darwin Core (DWC) does not specify domains and ranges. Currently, I am considering 'Salmon specimen and occurrence' to be the domain and 'Author citation' to be the range.</rdfs:comment>
+    <rdfs:range rdf:resource="http://purl.dataone.org/odo/SALMON_00000495"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A261">
+    <dc:source>https://en.wikipedia.org/wiki/Salmo, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q310436, accessed 2021-06-15</dc:source>
+    <owl:annotatedTarget>Salmo is a genus of fish in the salmon family Salmonidae that includes the European species of salmon and trout, among them the familiar Atlantic salmon Salmo salar and the brown trout Salmo trutta.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000589"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A262">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>When done correctly, this identification type will last the entire life of the fish, and is used for group marking.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000535"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000827">
+    <rdfs:label xml:lang="en">Occurrence record(s)</rdfs:label>
+    <j.4:hasDbXref>http://rs.tdwg.org/dwc/terms/Occurrence</j.4:hasDbXref>
+    <dc:description>Instances of this Class contain one or more occurrence records, and may  contain other information associated with those occurrences.
+
+"Occurrence" is used here in the sense of its Darwin Core definition:
+
+"An existence of an Organism (sensu http://rs.tdwg.org/dwc/terms/Organism) at a particular place at a particular time."</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-12T01:31:25Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <owl:equivalentClass rdf:nodeID="A137"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000188">
+    <skos:definition>The number of years or winters a salmon spends in a freshwater environment as a free-swimming fish.</skos:definition>
+    <rdfs:label xml:lang="en">Freshwater age</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-06T23:10:05Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000407"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000718">
+    <skos:definition>Total number of recruits of age class 3.1.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 3.1 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:51:54Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000667"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000803">
+    <rdfs:label xml:lang="en">Red salmon</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-21T23:26:30Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000463"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000242"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000164">
+    <skos:definition>Fishing gear which is used to collect fish and can be operated by hand by one or few people. Hand collection methods may also include the collection of fish without the aid of any gear (i.e. gathering live fish or carcasses using only one's hands).</skos:definition>
+    <rdfs:label xml:lang="en">Hand collection</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T18:47:27Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000142"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#MeasurementType">
+    <skos:definition>A MeasurementType describes the type of a Measurement in which the Measurement would follow the associated Protocol to record the value of the associated Characteristic of the associated Entity using the associated Standard. Any of these associated properties may be omitted, in which case the MeasurementType is only constrained by the provided associations. A MeasurementType is a hypothetical construct, in that it is not associated with a particular instance of a Measurement.</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000162">
+    <skos:definition>A type of net which hangs vertically in the water with its bottom edge held down by weights and its top edge buoyed by floats. Seine nets can be deployed from the shore as a beach seine, or from a boat.</skos:definition>
+    <skos:closeMatch rdf:resource="http://vocab.nerc.ac.uk/collection/M13/current/015/"/>
+    <rdfs:label xml:lang="en">Seine</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T18:32:41Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000163"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002566">
+    <rdfs:label xml:lang="en">lake name</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-26T22:54:25Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002768"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002239">
+    <rdfs:label xml:lang="en">longitude degree component</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-28T21:35:36Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002132"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A263">
+    <dc:source rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C461"/>
+    <owl:annotatedTarget>Tag based on application of chemical agents used to enhance the color or contrast of target materials or samples. Dyes have some affinity for their substrates and are usually applied in a solution.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000539"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A264">
+    <rdfs:comment>I altered the definition slightly from ENVO to include "...accumulation of SALINE water..." but have left this as owl:equivalentClass since ENVO axiomatizes 'marine water body' (http://purl.obolibrary.org/obo/ENVO_00001999) as 'composed primarily of some sea water'.  MPS changed from owl:equivalentClass being used as an Annot Prop to skos:exactMatch</rdfs:comment>
+    <owl:annotatedTarget>http://purl.obolibrary.org/obo/ENVO_00001999</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#exactMatch"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000203"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000717">
+    <skos:definition>Total number of recruits of age class 2.9.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 2.9 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:50:43Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000666"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000187">
+    <skos:definition>The sum of freshwater and marine annuli plus one to account for time spent in the gravel before hatching.</skos:definition>
+    <rdfs:label xml:lang="en">Total age</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-06T22:51:22Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000407"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000802">
+    <rdfs:label xml:lang="en">Silver salmon</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-21T23:15:02Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000462"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A265">
+    <dc:source>https://en.wikipedia.org/wiki/Fish_hatchery, accessed 2021-04-02
+https://www.wikidata.org/wiki/Q15615109, accessed 2021-04-02</dc:source>
+    <owl:annotatedTarget>The artificial breeding, hatching, and rearing through the early life stages of animals -- finfish and shellfish in particular. Hatcheries produce larval and juvenile fish, shellfish, and crustaceans, primarily to support the aquaculture industry where they are transferred to on-growing systems, such as fish farms, to reach harvest size.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000173"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000185">
+    <skos:definition>The way in which age is determined for a given individual.</skos:definition>
+    <skos:closeMatch>http://purl.dataone.org/odo/ECSO_00001602</skos:closeMatch>
+    <rdfs:label xml:lang="en">Fish age determination method</rdfs:label>
+    <dc:description>There are three basic methods for age and growth determination of fishes: (1) observation of the growth of fishes of known age, (2) study of fish size-frequencies, and (3) study of seasonal ring formation in hard body parts such as scales and bones.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-06T22:49:05Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000182"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A57">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000642"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2006/time#hasTemporalDuration">
+    <skos:definition>Duration of a temporal entity.</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000186">
+    <skos:definition>The way in which sex is determined for a given individual.</skos:definition>
+    <skos:closeMatch>http://purl.dataone.org/odo/ECSO_00001601</skos:closeMatch>
+    <rdfs:label xml:lang="en">Fish sex determination method</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-06T22:50:14Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000182"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000716">
+    <skos:definition>Total number of recruits of age class 2.8.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 2.8 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:50:39Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000666"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000825">
+    <rdfs:label xml:lang="en">Bristol Bay</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-10T22:44:31Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000224"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000801">
+    <rdfs:label xml:lang="en">Dog salmon</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-21T23:13:40Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000461"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A266">
+    <dc:source>https://en.wikipedia.org/wiki/Subregion</dc:source>
+    <owl:annotatedTarget>A subregion is a part of a larger region or continent and is usually based on location. Cardinal directions, such as south or sou commonly used to define a subregion.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000679"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A267">
+    <j.4:hasDbXref>https://www.adfg.alaska.gov/static/license/fishing/pdfs/coar_fish_codes.pdf, accessed 04May2021</j.4:hasDbXref>
+    <owl:annotatedTarget>The Alaska Department of Fish and Game defines unique two-digit "Codes for the Commercial Operator's Annual Report" which represent each of the gear types and harvest methods used Alaskan fisheries.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000527"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000184">
+    <skos:definition>The duration of time for which a fish has been alive.</skos:definition>
+    <skos:closeMatch>http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C25150</skos:closeMatch>
+    <rdfs:label xml:lang="en">Fish age measurement type</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-06T22:46:36Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000167"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000160">
+    <skos:relatedMatch rdf:resource="http://vocab.nerc.ac.uk/collection/M13/current/013/"/>
+    <skos:definition>A wall of netting which hangs in the water column, typically made of monofilament or multifilament nylon. Mesh sizes are designed to allow fish to get only their head through the netting but not their body. The fish's gills then get caught in the mesh as the fish tries to back out of the net. As the fish struggles to free itself, it becomes more and more entangled.</skos:definition>
+    <rdfs:label xml:lang="en">Gillnet</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T18:31:54Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000163"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A268">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>A numeric or alphanumeric code, which represents a particular species and may be recorded in place of a formal scientific or vernacular name.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000523"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A153">
+    <owl:unionOf rdf:nodeID="A69"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A269">
+    <dc:source>http://www.touchngo.com/lglcntr/akstats/statutes/title16/chapter05/section258.htm, accessed 2021-04-27</dc:source>
+    <owl:annotatedTarget>In Alaska, subsistence fisheries may not operate in "nonsubsistence areas" as designated by the state (AS 16.05.258(c)).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000172"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_">
+    <j.0:GitRepository>https://github.com/DataONEorg/sem-prov-ontologies</j.0:GitRepository>
+    <rdfs:label>Salmon Ontology</rdfs:label>
+    <rdfs:comment>Draft ontology to support Semantic Annotation of SASAP and salmon-related datasets housed in the SASAP Data Portal (https://knb.ecoinformatics.org/portals/SASAP/About).
+
+April 7, 2022 UPDATE (Mark Schildhauer; schild@nceas.ucsb.edu)
+This version of the salmon ontology preserves all terms and their original URI identifiers ("GUIDS") used to semantically annotate datasets in the SASAP data archives as of April 7, 2022, while also containing a number of additional terms that are not yet used.
+
+There are a number of "provisional" terms that have been added throughout the Ontology, i.e. as Classes, Individuals, Object, Datatype and Annotation Properties-- some are stubs for further axiomatization, other patterns are experimental and need to be cleaned up or revised as work progresses.
+
+In addition, a number of relationships have been created-- using Object Properties, Existential and Universal Quantifier Axioms, and "Annotation Properties as Flags"-- are in this Ontology due to experimentation with various approaches to inferencing. These are especially apparent in the treatment of Taxonomic and Vernacular names of Pacific Salmon. These should also be considered provisional and experimental.
+
+None of these issues should impact proper interpretation of annotated items in our SASAP archive
+
+Developed with Protege 5.5.0
+Inferences using  Pellet
+
+==============
+creator: Samantha Csik, scsik@nceas.ucsb.edu
+created: 2021-04-12
+updated: 2021-06-14
+2021-07-20 mps (schild@nceas.ucsb.edu)
+2021-08-05 mps (schild@nceas.ucsb.edu)
+2021-08-09 mps (schild@nceas.ucsb.edu)
+2021-08-11 mps (schild@nceas.ucsb.edu)
+2021-08-13 mps (schild@nceas.ucsb.edu)
+   merged in missing Classes from Sam's earlier version
+2021-09-08 mps (schild@nceas.ucsb.edu)
+   corrected all ID's to be 8 chars long
+2021-10-04 mps with import of ENVO "ecology" subset
+2021-10-13 mps added fisheries types; test modeling of different representation of taxonomies-- scoped domains/ranges?
+2021-11-15 mps fixed "Age class Y" recruits to "Age class Y.x recruits" etc
+removed some test Classes 2021-12-21 mps
+2022-01-13 mps: reorganized the "Names" and "Code" Classes and added comments
+2022-01-13 mps: added comments where flagged by Sam as missing
+2022-01-28 mps: imported Geosparql 1.0
+2022-02-03 mps:added some classes; refined descriptions that Sam had flagged as needing attention
+2022-02-17 mps: the ENVO Subset import is now deprecated due to change in the build workflow of ENVO, making its original import materialization inaccessible.
+2022-03-24 mps: added more salmon common names, searching for most concise way to infer equivalences of vernacular and scientifically named types/individuals...NOT YET FULLY RESOLVED
+2022-03-31 mps: removed SKOS-DL import from Object Properties but a number of "Usages" of SKOS-DL structures still need to be cleansed
+2022-04-06 mps: discussed Import process with ENVO folks, and was able to successfully re-import the "astronomical-body-part-hiearchy.owl" subset that contains a number of useful entities that are nicely organized and axiomatized.
+2022-04-07 mps: sent current revision to Bryce for upload to Ontology dereference PURLs that are provided as semantic annotations to data components in our SASAP data archive
+
+EOF</rdfs:comment>
+    <dcterms:license>https://creativecommons.org/publicdomain/zero/1.0/</dcterms:license>
+    <owl:versionIRI rdf:resource="http://purl.dataone.org/odo/SALMON/0.3.1"/>
+    <dcterms:creator>https://orcid.org/0000-0002-5300-3075
+https://orcid.org/0000-0002-0381-3766
+https://orcid.org/0000-0003-0632-7576
+https://orcid.org/0000-0003-0077-4738</dcterms:creator>
+    <owl:imports rdf:resource="http://www.opengis.net/ont/geosparql"/>
+    <j.4:default-namespace>SALMON</j.4:default-namespace>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTimeStamp">2021-04-12T11:02:10-07:00</dc:date>
+    <owl:imports rdf:resource="http://purl.obolibrary.org/obo/envo/releases/2021-05-14/subsets/astronomical-body-part-hierarchy.owl"/>
+    <owl:imports rdf:resource="http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl"/>
+    <owl:versionInfo>0.3.1</owl:versionInfo>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
+    <dc:description>An ontology representing knowledge about salmon, features of their habitats, salmon stakeholders, and related entities. This ontology is considered to be in the early stages of development, though it is based upon considerable previous work. Contributions of all kinds are welcome and encouraged, including alignments, updates to existing terms, and new terms.</dc:description>
+    <j.0:bug-database>https://github.com/DataONEorg/sem-prov-ontologies/issues</j.0:bug-database>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A270">
+    <dc:source rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C43459"/>
+    <owl:annotatedTarget>In biological taxonomy, Type generically refers to the official name applied to a taxon. This Class constrains Type members as belonging to family Salmonidae</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000458"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A271">
+    <dc:source>https://en.wikipedia.org/wiki/Rainbow_trout, accessed 2021-06-16
+https://www.wikidata.org/wiki/Q187986, accessed 20212-06-16</dc:source>
+    <owl:annotatedTarget>In 1855, William P. Gibbons, the curator of Geology and Mineralogy at the California Academy of Sciences, found a population and named it Salmo iridia (Latin: rainbow), later corrected to Salmo irideus. These names faded once it was determined that Walbaum's description of type specimens was conspecific and therefore had precedence. In 1989, morphological and genetic studies indicated that trout of the Pacific Basin were genetically closer to Pacific salmon (Oncorhynchus species) than to the Salmos – brown trout (Salmo trutta) or Atlantic salmon (Salmo salar) of the Atlantic Basin. Thus, in 1989, taxonomic authorities moved the rainbow, cutthroat, and other Pacific Basin trout into the genus Oncorhynchus. Walbaum's name had precedence, so the species name Oncorhynchus mykiss became the scientific name of the rainbow trout. The previous species names irideus and gairdneri were adopted as subspecies names for the coastal rainbow and Columbia River redband trout, respectively.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000646"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A272">
+    <dc:source>http://purl.obolibrary.org/obo/ENVO_00000475</dc:source>
+    <owl:annotatedTarget>An opening of the sea into the land, or of a lake into its shore.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000222"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000739">
+    <skos:definition>Total number of recruits of age class 5.4.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 5.4 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:56:01Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000669"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A273">
+    <dc:source rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:annotatedTarget>The weight of a fish, taken after the specimen has been frozen.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000660"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000715">
+    <skos:definition>Total number of recruits of age class 2.7.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 2.7 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:50:32Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000666"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000800">
+    <rdfs:label xml:lang="en">Humpback salmon</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-21T23:13:14Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A274">
+    <j.4:hasDbXref>http://vocab.nerc.ac.uk/collection/M13/current/018/, accessed 2021-04-02</j.4:hasDbXref>
+    <dc:source>https://en.wikipedia.org/wiki/Aquaculture, accessed 2021-04-02
+https://www.wikidata.org/wiki/Q188989, accessed 2021-04-02</dc:source>
+    <owl:annotatedTarget>The culturing of fish, shellfish, aquatic plants, and/or other organisms in captivity or under controlled conditions in the near shore environment.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000176"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A275">
+    <dc:source rdf:resource="http://purl.obolibrary.org/obo/PCO_0000003"/>
+    <owl:annotatedTarget>Includes qualities like population size, population growth rate, carrying capacity, immigration rate, emigration rate, fecundity, and death rate. A population quality may depend on the qualities of individual organisms in the population, but cannot be measured or described for a single organism.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000476"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002547">
+    <rdfs:label xml:lang="en">valley name</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-25T22:43:37Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002768"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A276">
+    <j.4:hasDbXref>https://risaa.org/newsletter/0516/0516_09.pdf, accessed 2021-05-06</j.4:hasDbXref>
+    <owl:annotatedTarget>A pectoral fin is removed, typically as close to the body as possible, using scissors or a razor blade.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000560"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000629">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/PCO_0000010</skos:exactMatch>
+    <skos:definition>The number of different species represented in an ecological community.</skos:definition>
+    <rdfs:label xml:lang="en">Species richness</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-04T22:06:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000503"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000738">
+    <skos:definition>Total number of recruits of age class 5.3.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 5.3 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:55:54Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000669"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000847">
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000460"/>
+    <rdfs:label xml:lang="en">Humpback salmon</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-10-07T01:18:28Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000714">
+    <skos:definition>Total number of recruits of age class 2.6.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 2.6 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:50:27Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000666"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000823">
+    <rdfs:label xml:lang="en">non-anadromous</rdfs:label>
+    <rdfs:comment>Fish belonging to a taxon that is typically anadromous, that do not migrate seaward at some time in their life-cycle.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T06:33:41Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A277">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>This identification type will last the lifetime of the fish, is used for group marking, and is most suitable for salmonids that are at least 7cm in length.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000544"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000182">
+    <skos:definition>The manner, procedure or technique by which a morphological or physiological state or property in a single fish or sample or a group of fish(es) or samples is assessed and a quantitative or qualitative value assigned.</skos:definition>
+    <rdfs:label xml:lang="en">Fish measurement method</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-05T21:55:12Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000205"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A278">
+    <j.4:hasDbXref>http://purl.obolibrary.org/obo/MMO_0000000</j.4:hasDbXref>
+    <owl:annotatedTarget>The manner, procedure or technique by which a morphological or physiological state or property in a single fish or sample or a group of fish(es) or samples is assessed and a quantitative or qualitative value assigned.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000182"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A279">
+    <dc:source>https://www.researchgate.net/profile/Darlene-Gillespie/publication/281285926_Chinook_Salmon_Oncorhynchus_tshawytscha_Scale_Age_Determination_Procedures/links/55df66d708aede0b572b8de7/Chinook-Salmon-Oncorhynchus-tshawytscha-Scale-Age-Determination-Procedures.pdf, accessed 20212-04-09
+
+https://pdxscholar.library.pdx.edu/cgi/viewcontent.cgi?article=3220&amp;context=open_access_etds, accessed 20212-04-09</dc:source>
+    <owl:annotatedTarget>An age designation notation that includes two numbers, of which the second is a subscript. The first numeral indicates the total age of the fish and the subscript indicates the time spent in freshwater prior to saltwater immigration.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000201"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A280">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>An ink solution, which is injected into the skin.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000555"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A281">
+    <j.4:hasDbXref>http://purl.dataone.org/odo/ECSO_00000553</j.4:hasDbXref>
+    <owl:annotatedTarget>A numerical value which represents the length of a fish, typically in units of millimeters, centimeters, or inches.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000127"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A95">
+    <rdf:rest rdf:nodeID="A282"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000460"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000519">
+    <skos:relatedMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000492"/>
+    <rdfs:label xml:lang="en">Year of commercial fish harvest</rdfs:label>
+    <rdfs:comment>The Year in which some commercial fish harvest was taken.  Given a Class structure here to enable filtering by Year(s) of interest, although this temporal descriptor could and should also be assigned to any observations of "Commercial Fish Harvest", e.g. potentially by using the SOSA:PhenomenonTime attribute.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-04T17:21:48Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000518"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000628">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/PCO_0000023</skos:exactMatch>
+    <skos:definition>A quality of an ecological community that reflects how close in abundance all species in a community are.</skos:definition>
+    <rdfs:label xml:lang="en">Species evenness</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-04T22:05:10Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000503"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000737">
+    <skos:definition>Total number of recruits of age class 5.2.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 5.2 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:55:50Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000669"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A283">
+    <dc:source rdf:resource="http://purl.obolibrary.org/obo/PCO_0000003"/>
+    <owl:annotatedTarget>A quality that inheres in a population of organisms.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000476"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000846">
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000462"/>
+    <rdfs:label xml:lang="en">Silver salmon</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-10-07T01:15:21Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000713">
+    <skos:definition>Total number of recruits of age class 2.5.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 2.5 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:50:22Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000666"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A284">
+    <j.4:hasDbXref>https://www.fisheries.noaa.gov/national/bycatch/fishing-gear-traps-and-pots, accessed 2021-04-01</j.4:hasDbXref>
+    <owl:annotatedTarget>A three-dimensional wire or wood device which is submerged and commonly baited. A pot (or "trap") permits organisms to enter the enclosure, but makes escape extremely difficult or impossible.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000150"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002169">
+    <rdfs:label xml:lang="en">year and season</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-22T22:55:13Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00001167"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A285">
+    <rdf:rest rdf:nodeID="A259"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000462"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.obolibrary.org/obo/ENVO_00000032">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A286">
+    <dc:source>http://purl.dataone.org/odo/ECSO_00001104</dc:source>
+    <owl:annotatedTarget>Temperature is measured with thermometers that may be calibrated to a variety of temperature scales. Most scientists measure temperature using the Celsius scale and thermodynamic temperature using the Kelvin scale, which is the Celsius scale offset so that its null point is 0K = −273.15°C, or absolute zero. The basic unit of temperature in the International System of Units (SI) is the kelvin. It has the symbol K.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000217"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://schema.org/Dataset">
+    <rdfs:comment>A body of structured information describing some topic(s) of interest.  (schema.org)</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000695">
+    <skos:definition>Total number of recruits of age class 0.5.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 0.5 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:45:39Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000664"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000671">
+    <skos:definition>A numeric or alphanumeric code, which represents a particular salmon stock and may be recorded in place of a formal scientific or vernacular name.</skos:definition>
+    <rdfs:label xml:lang="en">Fish stock code</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-17T17:12:48Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000672"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000780">
+    <skos:altLabel>Anadromous Waters Catalog water body code
+State of Alaska's Anadromous Waters Stream Catalog</skos:altLabel>
+    <rdfs:label xml:lang="en">AWC water body code</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-19T20:55:57Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000572"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A287">
+    <dc:source>https://en.wikipedia.org/wiki/Seine_fishing, accessed 01April2021
+https://www.wikidata.org/wiki/Q600580, accessed 01April2021</dc:source>
+    <owl:annotatedTarget>A type of net which hangs vertically in the water with its bottom edge held down by weights and its top edge buoyed by floats. Seine nets can be deployed from the shore as a beach seine, or from a boat.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000162"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A288">
+    <dc:source rdf:resource="http://purl.obolibrary.org/obo/PCO_0000004"/>
+    <owl:annotatedTarget>A quality that inheres in a community.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000503"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000126">
+    <rdfs:label xml:lang="en">Pacific trout and char</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-30T21:00:02Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000458"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000235">
+    <skos:definition>The measured distance between the fine ridges of a scale (i.e. circuli) which are laid down annually in a circular pattern around the focus, or center, of a scale as the growth of the fish proceeds.</skos:definition>
+    <rdfs:label xml:lang="en">Distance between scale circuli</rdfs:label>
+    <rdfs:comment>An Essential Salmon Variable (ESV) from the working list being developed by Graeme Diack et al. at the Atlantic Salmon Trust.</rdfs:comment>
+    <dc:description>Circuli are more widely spaced in warmer months when food is abundant and growth is rapid, and more narrowly spaced in colder months when food availability is low and growth slows.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-15T19:38:49Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000234"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000586">
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000590"/>
+    <skos:altLabel>Salmo salar
+S. salar</skos:altLabel>
+    <rdfs:label xml:lang="en">Atlantic salmon</rdfs:label>
+    <dc:description>Atlantic salmon are the only anadromous salmonid native to the Atlantic coast of North America.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-26T23:51:30Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000458"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A289">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>If performed correctly, this identification type may remain attached for the entire life of the fish, is used for individual tagging, and is most suitable for fish at least 15cm in length and which live in open environments. To attach a Carlin tag, double cannulas are first inserted through the fish at the height of the center of the pterygiophores (the bones that support the dorsal fin). Two stainless steel wires are then pulled through the cannulas and then the cannulas are pulled out of the fish. A small metal plate with an alphanumeric code is atached to the steel wires, which are then twisted tightly against the fish's body to hold the plate in place.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000548"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A290">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Fish_migration, accessed 01June2021
+https://www.wikidata.org/wiki/Q852569, accessed 01June2021</j.4:hasDbXref>
+    <owl:annotatedTarget>A classification of fishes which spawn in marine habitats, migrate to freshwater areas to forage and mature, then return to marine habitats to spawn.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000616"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://usefulinc.com/ns/doap#bug-database">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000694">
+    <skos:definition>Total number of recruits of age class 0.4.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 0.4 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:45:17Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000664"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000670">
+    <skos:definition>Total number of recruits of age class six.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 6.x recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-06-17T16:31:20Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000855"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000561">
+    <skos:definition>The right pectoral fin of the fish is removed.</skos:definition>
+    <rdfs:label xml:lang="en">Right pectoral fin clip</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-06T16:58:12Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000560"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000476">
+    <skos:definition>A quality that inheres in a population of organisms.</skos:definition>
+    <rdfs:label xml:lang="en">Quality of a population measurement type</rdfs:label>
+    <rdfs:comment>[NEEDS ALIGNMENT]
+
+http://purl.obolibrary.org/obo/PCO_0000003</rdfs:comment>
+    <dc:description>Includes qualities like population size, population growth rate, carrying capacity, immigration rate, emigration rate, fecundity, and death rate. A population quality may depend on the qualities of individual organisms in the population, but cannot be measured or described for a single organism.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-26T22:37:24Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#MeasurementType"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000234">
+    <rdfs:label xml:lang="en">Fish age proxy measurement type</rdfs:label>
+    <dc:description>Fish ages are often estimated using proxy measurements, such as the space or distance between scale circuli.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-15T19:38:17Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000484"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00001719">
+    <rdfs:label xml:lang="en">data quality assessment measurement type</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-11-30T05:06:00Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#MeasurementType"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A291">
+    <dc:source rdf:resource="https://www.wikidata.org/wiki/Q475211"/>
+    <dc:source rdf:resource="https://en.wikipedia.org/wiki/Chum_salmon"/>
+    <owl:annotatedTarget>Oncorhynchus keta
+O. keta
+"dog salmon" @en
+"keta salmon" @en
+"silverbrite salmon" @en</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000240"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A292">
+    <j.4:hasDbXref>https://www.monitoringresources.org/Document/Method/Details/1548, accessed 2021-06-14
+https://www.monitoringresources.org/Document/Method/Details/4041, accessed 2021-06-14</j.4:hasDbXref>
+    <owl:annotatedTarget>A fish measurement method in which the length from the hind margin of the orbit (i.e. eye) to the tip of the median caudal fin rays (i.e. fork) is recorded. Two common procedures are:
+
+(a) Using a measuring board: A fish is placed on its side on a measuring board with its snout against the rigid headpiece. A measurement is taken from hind margin of the orbit (i.e. eye) to the tip of the median caudal fin rays (i.e. fork).
+
+(b) Using a tape measure: A fish is placed on its side, either on top of a tape measure or the tape measure is placed just above the dorsal side of the fish to record the measurement from the hind margin of the orbit (i.e. eye) to the tip of the median caudal fin rays (i.e. fork). It is important to not allow the tape to curve along the contoured side of the fish that is facing up, which can introduce bias into the measurement due to girth.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000635"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000125">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/ENVO_00000063</skos:exactMatch>
+    <skos:definition>An accumulation of water of varying size.</skos:definition>
+    <skos:altLabel>waterbody
+body of water
+aquatic feature</skos:altLabel>
+    <rdfs:label xml:lang="en">Water body</rdfs:label>
+    <dc:description>The term body of water most often refers to large accumulations of water, such as oceans, seas, and lakes, but it includes smaller pools of water such as ponds, wetlands, or more rarely, puddles. A body of water does not have to be still or contained; Rivers, streams, canals, and other geographical features where water moves from one place to another are also considered bodies of water.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-30T20:59:53Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000202"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002450">
+    <rdfs:label xml:lang="en">observer confidence</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-19T21:55:20Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00001719"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A293">
+    <j.4:hasDbXref>https://www.fisheries.noaa.gov/national/bycatch/fishing-gear-gillnets, accessed 01April2021</j.4:hasDbXref>
+    <owl:annotatedTarget>A wall of netting which hangs in the water column, typically made of monofilament or multifilament nylon. Mesh sizes are designed to allow fish to get only their head through the netting but not their body. The fish's gills then get caught in the mesh as the fish tries to back out of the net. As the fish struggles to free itself, it becomes more and more entangled.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000160"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002123">
+    <rdfs:label xml:lang="en">days elapsed</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-16T21:22:28Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002068"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A294">
+    <owl:unionOf rdf:nodeID="A73"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A295">
+    <dc:source>https://en.wikipedia.org/wiki/Semelparity_and_iteroparity#Semelparity, accessed 01June2021
+https://www.wikidata.org/wiki/Q522960, accessed 01June2021</dc:source>
+    <owl:annotatedTarget>A reproductive strategy which is characterized by a single reproductive episode, typically before death.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000613"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A296">
+    <j.4:hasDbXref>https://code.iczn.org/authorship/article-51-citation-of-names-of-authors/?frame=1, accessed 2021-04-28</j.4:hasDbXref>
+    <owl:annotatedTarget>The International Code of Zoological Nomenclature (ICZN), a widely accepted convention in zoology that rules the formal scientific naming of organisms treated as animals, establishes guidelines for author citation. See Chapter 11 of the Fourth Edition.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000495"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A297">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Tributary, accessed 2021-04-07
+https://www.wikidata.org/wiki/Q159675, accessed 2021-04-07</j.4:hasDbXref>
+    <dc:source>http://purl.obolibrary.org/obo/ENVO_00000495</dc:source>
+    <owl:annotatedTarget>A stream or river which flows into another river (a parent river) or body of water but which may not flow directly into the sea.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000195"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A298">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>This identification type may be clearly visible for several months and can be felt for up to a year, is primarily used for group marking, and is most suitable for salmonids that are at least 7.5cm in length. Freeze branding is done by cooling a metal rod and/or brand in liquid nitrogen, then pressing the rod lightly against the fish for ~3sec. A dark spot is temporarily created and the fish's scales are deformed. The dark spot disappears after about a month, while the deformation of the scales can be seen at certain light angles and felt with fingers for up to a year.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000538"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000693">
+    <skos:definition>Total number of recruits of age class 0.3.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 0.3 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:44:58Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000664"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000560">
+    <skos:definition>A pectoral fin is removed, typically as close to the body as possible, using scissors or a razor blade.</skos:definition>
+    <rdfs:label xml:lang="en">Pectoral fin clip</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-06T16:58:02Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000540"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000584">
+    <skos:exactMatch>https://www.geonames.org/3373405/atlantic-ocean.html</skos:exactMatch>
+    <skos:exactMatch>http://purl.obolibrary.org/obo/GAZ_0000034</skos:exactMatch>
+    <skos:definition>An ocean bounded on the west by North and South America. In the north and northeast, it is separated from the Arctic Ocean by the Canadian Arctic Archipelago, Greenland, Iceland, Svalbard, and mainland Europe. It connects to the Arctic Ocean through the Denmark Strait, Greenland Sea, Norwegian Sea, and Barents Sea. To the east, the boundaries of the ocean proper are Europe, the Strait of Gibraltar (where it connects with the Mediterranean Sea, one of its marginal seas), and Africa. In the southeast, the Atlantic merges into the Indian Ocean, the border being defined by the 20 East meridian, running south from Cape Agulhas to Antarctica.</skos:definition>
+    <rdfs:label xml:lang="en">Atlantic Ocean</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-26T22:07:26Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000192"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000475">
+    <rdfs:label xml:lang="en">Walbaum, 1792</rdfs:label>
+    <rdfs:comment>Johann Julius Walbaum (30 June 1724, Wolfenbüttel, Brunswick-Wolfenbüttel – 21 August 1799, Lübeck) was a German physician, naturalist and fauna taxonomist.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-26T22:06:58Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000495"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000148">
+    <skos:definition>An obstruction placed in tidal waters, or wholly or partially across a river, to direct the passage of, or trap fish.</skos:definition>
+    <skos:altLabel>fish weir
+fishing weir
+fishgarth
+kiddle</skos:altLabel>
+    <rdfs:label xml:lang="en">Weir</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T18:01:41Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000142"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000499">
+    <rdfs:label xml:lang="en">Fish abundance</rdfs:label>
+    <rdfs:comment>General Class for organizing various measurements and estimates of the Abundance of Fish, that can involve methods focusing on assessments during different life-stages, using different harvest methods, etc.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-28T21:29:53Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000476"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000124">
+    <rdfs:label xml:lang="en">Place or location or region</rdfs:label>
+    <rdfs:comment>Union of Place and Location to enable searching over both less and more precise named designations of Regions</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-30T20:59:48Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000675"/>
+    <owl:equivalentClass rdf:nodeID="A294"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002122">
+    <rdfs:label xml:lang="en">day of month</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-16T21:15:01Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002043"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A299">
+    <dc:source>http://purl.obolibrary.org/obo/ENVO_00000032</dc:source>
+    <owl:annotatedTarget>An area of water bordered by land on three sides.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000224"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000691">
+    <skos:definition>Total number of recruits of age class 0.1.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 0.1 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:43:45Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000664"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A300">
+    <rdfs:comment>Note that this ENVO term, 'environmental feature' is deprecated</rdfs:comment>
+    <owl:annotatedTarget>http://purl.obolibrary.org/obo/ENVO_00002297</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000202"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00001167">
+    <skos:prefLabel>Temporal Measurement Type</skos:prefLabel>
+    <skos:hiddenLabel>temporal_MeasurementType</skos:hiddenLabel>
+    <rdfs:label>temporal_MeasurementType</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#MeasurementType"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000692">
+    <skos:definition>Total number of recruits of age class 0.2.</skos:definition>
+    <rdfs:label xml:lang="en">Age class 0.2 recruits</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-15T18:44:37Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000664"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000583">
+    <skos:exactMatch>https://www.geonames.org/2363254/pacific-ocean.html</skos:exactMatch>
+    <skos:exactMatch>http://purl.obolibrary.org/obo/GAZ_00000360</skos:exactMatch>
+    <skos:definition>An ocean that extends from the Arctic in the north to the Antarctic in the south, bounded by Asia and Australia on the west and the Americas on the east.</skos:definition>
+    <rdfs:label xml:lang="en">Pacific Ocean</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-26T22:07:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000192"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A301">
+    <j.4:hasDbXref>https://www.monitoringresources.org/Document/Method/Details/1549, accessed 2021-03-31
+https://www.monitoringresources.org/Document/Method/Details/4041, accessed 2021-03-31</j.4:hasDbXref>
+    <owl:annotatedTarget>A fish length measurement taken from the middle of the orbit (i.e. eye) to the tip of the median caudal fin rays (i.e. fork).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000133"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000232">
+    <skos:definition>A method which is used to approximate the age of a fish and which generally involves extracting the otoliths from a fish, then counting the number of annuli (i.e. year marks).</skos:definition>
+    <rdfs:label xml:lang="en">Counting otolith annuli</rdfs:label>
+    <rdfs:comment>Alaska Department of Fish &amp; Game, Division of Fisheries Rehabilitation, Enchancement and Development's report on Juvenile Salmonid Otolith Extraction and Preparation Techniques for Microscopic Examination can be accessed at: https://www.adfg.alaska.gov/fedaidpdfs/FRED.132.pdf</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-15T19:27:37Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000185"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000147">
+    <skos:definition>A gillnet which is attached to poles fixed in the substrate or an anchor system to prevent movement of the net.</skos:definition>
+    <skos:altLabel>set net</skos:altLabel>
+    <rdfs:label xml:lang="en">Set gillnet</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T18:01:36Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000160"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000809">
+    <rdfs:label xml:lang="en">Traditional fishery</rdfs:label>
+    <dc:source>http://www.oceansatlas.org/subtopic/en/c/1303/</dc:source>
+    <dc:description>Fisheries established long ago, usually by specific communities that have developed customary patterns of rules and operations. Traditional fisheries reflect cultural traits and attitudes and may be strongly influenced by religious practices or social customs. Knowledge is transmitted between generations by word of mouth. They are usually small-scale and/or artisanal.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-22T05:57:23Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000137"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000581">
+    <rdfs:label xml:lang="en">hasNativeWaterbody</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-26T21:41:26Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:range rdf:resource="http://purl.dataone.org/odo/SALMON_00000125"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A302">
+    <dc:source>http://purl.dataone.org/odo/ECSO_00001225</dc:source>
+    <owl:annotatedTarget>Objective comparative measure of hot or cold of air.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000218"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000231">
+    <skos:definition>A method which is used to approximate the age of a fish, and which generally involves removing and preserving a scale from a fish, then counting the number of annuli (i.e. year marks).</skos:definition>
+    <rdfs:label xml:lang="en">Measuring the distance between scale circuli</rdfs:label>
+    <rdfs:comment>A Basic Guide to Aging &amp; Identification of Pacific Salmon Scales by Alaska Department of Fish &amp; Game is available at: https://www.adfg.alaska.gov/static/education/educators/curricula/pdfs/salmon_scales_guide_aging_identification.pdf</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-15T19:25:23Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000185"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000582">
+    <skos:exactMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000594"/>
+    <skos:altLabel>Oncorhynchus clarkii
+O. clarkii</skos:altLabel>
+    <rdfs:label xml:lang="en">Cutthroat trout</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-26T21:45:56Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000126"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A303">
+    <dc:source>http://purl.obolibrary.org/obo/ENVO_00000137</dc:source>
+    <owl:annotatedTarget>An opening of the sea into the land.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000223"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000146">
+    <skos:definition>A barbed pole, which is used to strike and collect a fish. Spearheads come in a variety of different shapes (e.g. arrow, trident), and can be thrown by hand or deployed using elastic-powered spearguns and slings or compressed gas pneumatic powered spearguns.</skos:definition>
+    <rdfs:label xml:lang="en">Spear</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T18:01:30Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000164"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A304">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/Pink_salmon, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q673380, accessed 2021-06-15</j.4:hasDbXref>
+    <owl:annotatedTarget>Oncorhynchus gorbuscha (i.e. pink salmon) is the smallest and most abundant of the five species of Pacific salmon.
+
+Physical Description: In the ocean, pink salmon are bright silver fish. After returning to their spawning streams, their coloring changes to pale grey on the back with yellowish-white belly (although some turn an overall dull green color). As with all salmon, in addition to the dorsal fin, they also have an adipose fin. The fish is characterized by a white mouth with black gums, no teeth on the tongue, large oval-shaped black spots on the back, a v-shaped tail, and an anal fin with 13-17 soft rays. During their spawning migration, males develop a pronounced humped back, hence their nickname "humpies". Pink salmon average 4.8 pounds (2.2 kg) in weight. The maximum recorded size was 30 inches (76 cm) and 15 pounds (6.8 kg).
+
+Range: The native range of the species is in the Pacific and Arctic coastal waters and rivers, from the Sacramento River in northern California to the Mackenzie River in Canada; and in the west from the Lena River in Siberia to Korea and Honshu in Japan. In North America pink salmon spawn from the Mackenzie River in the Arctic to as far south as tributaries of Puget Sound, Washington, although they were also reported in the San Lorenzo River near Santa Cruz, California in 1915 and the Sacramento River in northern California in the 1950s. In 2013 a new record for the southernmost extent of spawning pink salmon was published for the Salinas River. In the fall of 2017 a dozen pink salmon were counted in Lagunitas Creek about 25 miles (40 km) north of San Francisco, California.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000460"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A126">
+    <owl:someValuesFrom rdf:resource="http://purl.dataone.org/odo/SALMON_00000884"/>
+    <owl:onProperty rdf:resource="http://rs.tdwg.org/dwc/terms/scientificName"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000580">
+    <j.1:SALMON_00000618 rdf:resource="http://purl.dataone.org/odo/SALMON_00000612"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:comment>Sea-running, i.e. anadromous individuals of Rainbow Trout, are called Steelhead.</rdfs:comment>
+    <j.2:nameAccordingTo rdf:resource="http://purl.dataone.org/odo/SALMON_00000475"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000591"/>
+    <j.1:SALMON_00000617 rdf:resource="http://purl.dataone.org/odo/SALMON_00000615"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SALMON_00000587"/>
+    <rdfs:label xml:lang="en">Oncorhynchus mykiss</rdfs:label>
+    <j.2:vernacularName rdf:resource="http://purl.dataone.org/odo/SALMON_00000643"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-26T21:27:02Z</dc:date>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A305">
+    <j.4:hasDbXref>https://www.researchgate.net/profile/Darlene-Gillespie/publication/281285926_Chinook_Salmon_Oncorhynchus_tshawytscha_Scale_Age_Determination_Procedures/links/55df66d708aede0b572b8de7/Chinook-Salmon-Oncorhynchus-tshawytscha-Scale-Age-Determination-Procedures.pdf, accessed 2021-04-06</j.4:hasDbXref>
+    <owl:annotatedTarget>The number of years or winters a salmon spends in a saltwater environment.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000189"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000808">
+    <rdfs:label xml:lang="en">Industrial Fishery</rdfs:label>
+    <dc:source>http://www.oceansatlas.org/subtopic/en/c/1303/</dc:source>
+    <dc:description>Capital-intensive fisheries using relatively large vessels with a high degree of mechanization and that normally have advanced fish finding and navigational equipment. Such fisheries have a high production capacity and the catch per unit effort is normally relatively high. In some areas of the world, the term "industrial fisheries" is synonymous with fisheries for species that are used for reduction to fishmeal and fish oil (e.g. the trawl fishery for sandeel in the North Sea or the Peruvian ourse-seine fishery for anchoveta).</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-22T05:53:20Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000137"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/ECSO_00002366">
+    <rdfs:label xml:lang="en">season</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-05-17T22:41:45Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00002169"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A306">
+    <dc:source>http://semanticscience.org/resource/SIO_000414</dc:source>
+    <owl:annotatedTarget>A spatial region whose boundaries are typically defined against some material frame of reference (like the earth).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000678"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A307">
+    <j.4:hasDbXref>http://purl.obolibrary.org/obo/ENVO_00001999</j.4:hasDbXref>
+    <owl:annotatedTarget>A significant accumulation of saline water which is part of a marine biome.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000203"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://rs.tdwg.org/dwc/terms/vernacularName">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000145">
+    <skos:definition>A device which (a) is situated in rivers for catching fish, and (b) looks and operates like a watermill that is outfitted with wire baskets designed to catch and carry fish from the water and into a nearby holding tank.</skos:definition>
+    <skos:altLabel>salmon wheel</skos:altLabel>
+    <rdfs:label xml:lang="en">Fish wheel</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T18:01:23Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000142"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000230">
+    <skos:exactMatch>http://purl.obolibrary.org/obo/ENVO_00000029</skos:exactMatch>
+    <skos:definition>A flowing body of water.</skos:definition>
+    <rdfs:label xml:lang="en">Watercourse</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-15T18:52:49Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000196"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000169">
+    <skos:definition>A fishery in which fishes and other seafood are harvested for commercial profit, mostly from wild fisheries.</skos:definition>
+    <rdfs:label xml:lang="en">Commercial fishery</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-02T19:59:17Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000137"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A308">
+    <dc:source>https://en.wikipedia.org/wiki/Cutthroat_trout, accessed 2021-06-15
+https://www.wikidata.org/wiki/Q2717060, accessed 2021-06-15</dc:source>
+    <owl:annotatedTarget>Oncorhynchus clarkii
+O. clarkii</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000582"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000807">
+    <rdfs:label xml:lang="en">Small-scale fishery</rdfs:label>
+    <dc:source>http://www.oceansatlas.org/subtopic/en/c/1303/</dc:source>
+    <dc:description>Labour-intensive fisheries using relatively small crafts (if any) and little capital and equipment per person-on-board. Most often family-owned. May be commercial or for subsistence (see below). Usually low fuel consumption. Often equated with artisanal fisheries.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-22T05:52:51Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000137"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A309">
+    <rdfs:comment>"MEFK" is an acronym used by Alaska Department of Fish &amp; Game (ADF&amp;G)</rdfs:comment>
+    <owl:annotatedTarget>MEFK
+Mid-eye to fork of tail</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000133"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A310">
+    <j.4:hasDbXref>https://jordbruksverket.se/download/18.38d764e9177375620998e232/1611738582157/Rapport-Fish-identification-marking-and-tagging-methods.pdf, accessed 2021-05-05</j.4:hasDbXref>
+    <owl:annotatedTarget>An appearance that varies between individuals.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000552"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A311">
+    <j.4:hasDbXref>http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C28421</j.4:hasDbXref>
+    <owl:annotatedTarget>A categorical measurement type which describes the sex of a fish or group of fish(es), where sex is defined as the assemblage of physical properties or qualities of a fish by which male is distinguished from female; the physical difference between male and female; the distinguishing peculiarity of male or female.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000216"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A312">
+    <dc:source rdf:resource="http://purl.dataone.org/odo/ECSO_00001164"/>
+    <owl:annotatedTarget>Salinity is an important factor in determining many aspects of the chemistry of natural waters and of biological processes within it, and is a thermodynamic state variable that, along with temperature and pressure, governs physical characteristics like the density and heat capacity of the water.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000416"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A313">
+    <dc:source rdf:resource="http://purl.obolibrary.org/obo/PCO_0000010"/>
+    <owl:annotatedTarget>The number of different species represented in an ecological community.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000629"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/creator">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000144">
+    <skos:relatedMatch rdf:resource="http://vocab.nerc.ac.uk/collection/M13/current/014/"/>
+    <skos:definition>Fishing by means of an "angle" (fish hook). The hook is usually attached to a fishing line and baited with natural bait or artificial lures to attract fish. The line is often attached to a fishing rod.</skos:definition>
+    <skos:altLabel>hook and line</skos:altLabel>
+    <rdfs:label xml:lang="en">Angling</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T18:01:18Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000164"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000495">
+    <skos:definition>The name of the scientist or scientists who first validly published the scientific name of a particular organism.</skos:definition>
+    <skos:altLabel>taxonomic authority
+authority</skos:altLabel>
+    <rdfs:label xml:lang="en">Author citation</rdfs:label>
+    <rdfs:comment>For example, in 1758 Linnaeus gave the Asian elephant the scientific name Elephas maximus, so the name is sometimes written as "Elephas maximus Linnaeus, 1758".</rdfs:comment>
+    <dc:description>The International Code of Zoological Nomenclature (ICZN), a widely accepted convention in zoology that rules the formal scientific naming of organisms treated as animals, establishes guidelines for author citation. See Chapter 11 of the Fourth Edition.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-28T20:18:16Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A314">
+    <j.4:hasDbXref>https://www.monitoringresources.org/Document/Method/Details/1549, accessed 2021-06-14
+https://www.seagrant.wisc.edu/our-work/focus-areas/fish-and-fisheries/fish-glossary/, accessed 2021-06-14</j.4:hasDbXref>
+    <owl:annotatedTarget>A fish measurement method in which the length from the middle of the orbit (i.e. eye) to the the posterior-most point where the fin connects with the body is recorded. Two common procedures are:
+
+(a) Using a measuring board: A fish is placed on its side on a measuring board with its snout against the rigid headpiece. A measurement is taken from the middle of the orbit (i.e. eye) to the posterior-most point where the fin connects with the body.
+
+(b) Using a tape measure: A fish is placed on its side, either on top of a tape measure or the tape measure is placed just above the dorsal side of the fish to record the measurement from the middle of the orbit (i.e. eye) to the posterior-most point where the fin connects with the body. It is important to not allow the tape to curve along the contoured side of the fish that is facing up, which can introduce bias into the measurement due to girth.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000634"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A282">
+    <rdf:rest rdf:nodeID="A285"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000461"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A315">
+    <dc:source>https://www.monitoringresources.org/Document/Method/Details/4041, accessed 2021-06-14</dc:source>
+    <owl:annotatedTarget>The fork length measurement method is commonly used in fish species that have forked caudal fins -- where the dorsal and ventral rays are longer than median rays. Longer rays are often damaged or eroded by contact with rocks, debris, or hatchery walls.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000631"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000493">
+    <rdfs:label xml:lang="en">Fish biomass</rdfs:label>
+    <rdfs:comment>A measurement of the weight of a fish, or of a sample of fish/fishes</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-28T18:42:51Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000476"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A70">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SALMON_00000571"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A316">
+    <dc:source>http://purl.obolibrary.org/obo/ENVO_00000393</dc:source>
+    <owl:annotatedTarget>A large sea or ocean inlet larger than a bay, deeper than a bight, wider than a fjord, or it may identify a narrow sea or ocean channel between two bodies of land.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000226"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A317">
+    <j.4:hasDbXref>http://vocab.nerc.ac.uk/collection/M13/current/015/, accessed 01April2021</j.4:hasDbXref>
+    <dc:source>https://www.fisheries.noaa.gov/national/bycatch/fishing-gear-purse-seines, accessed 01April2021</dc:source>
+    <owl:annotatedTarget>A large wall of netting deployed around an entire area or school of fish. The seine has floats along the top line with a lead line threaded through rings along the bottom. Once a school of fish is located, a skiff encircles the school with the net. The lead line is then pulled in, "pursing" the net closed on the bottom, preventing fish from escaping by swimming downward. The catch is harvested by either hauling the net aboard or bringing it alongside the vessel.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000158"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A318">
+    <dc:source>https://en.wikipedia.org/wiki/Location</dc:source>
+    <owl:annotatedTarget>In geography, location or place are used to denote a region (point, line, or area) on Earth’s surface or elsewhere. The term location generally implies a higher degree of certainty than place, the latter often indicating an entity with an ambiguous boundary, relying more on human or social attributes of place identity and sense of place than on geometry.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000677"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A319">
+    <j.4:hasDbXref>https://en.wikipedia.org/wiki/River, accessed 2021-04-07
+https://www.wikidata.org/wiki/Q4022, accessed 2021-04-07</j.4:hasDbXref>
+    <dc:source>http://purl.obolibrary.org/obo/ENVO_00000022</dc:source>
+    <owl:annotatedTarget>A stream which, through permanent or seasonal flow processes, moves from elevated land towards lower elevations through a definite channel and empties either into a sea, lake, or another river or ends on land as bed seepage and evapotranspiration exceed water supply.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000190"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://usefulinc.com/ns/doap#GitRepository">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000494">
+    <skos:definition>A reference which is made to a taxon name along with a publication which explains how the author intends for the name to be applied.</skos:definition>
+    <skos:altLabel>taxonomic concept</skos:altLabel>
+    <rdfs:label xml:lang="en">Taxon concept</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-28T19:23:01Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000829"/>
+    <owl:equivalentClass rdf:nodeID="A22"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000167">
+    <skos:definition>A measurement type taken of some physical, biological, or ecological aspect of a fish or fishes.</skos:definition>
+    <rdfs:label xml:lang="en">Fish measurement type</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-01T21:37:39Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#MeasurementType"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_00000806">
+    <rdfs:label xml:lang="en">Grilse</rdfs:label>
+    <dc:description>a young Atlantic salmon returning to its native river to spawn for the first time after one winter at sea</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-07-22T02:58:24Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0632-7576"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SALMON_00000401"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A320">
+    <dc:source>https://en.wikipedia.org/wiki/Location</dc:source>
+    <owl:annotatedTarget>In geography, location or place are used to denote a region (point, line, or area) on Earth’s surface or elsewhere. The term location generally implies a higher degree of certainty than place, the latter often indicating an entity with an ambiguous boundary, relying more on human or social attributes of place identity and sense of place than on geometry.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SALMON_00000676"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/src/main/resources/ontologies/SALMON_alignment.owl
+++ b/src/main/resources/ontologies/SALMON_alignment.owl
@@ -1,0 +1,639 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:j.0="http://purl.org/dc/terms/"
+    xmlns:j.1="http://purl.obolibrary.org/obo/"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:j.2="http://usefulinc.com/ns/doap#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" > 
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000728">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000728"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 4.2 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000728. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000728"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000659">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000659"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Wet weight</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000659. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000659"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000647">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000647"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Oncorhynchus mykiss irideus</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000647. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000647"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000712">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000712"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 2.4 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000712. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000712"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000700">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000700"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 1.5 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000700. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000700"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000667">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000667"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 3.x recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000667. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000667"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000699">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000699"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 1.4 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000699. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000699"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000720">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000720"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 3.3 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000720. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000720"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000663">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000663"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Total recruit abundance</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000663. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000663"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000695">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000695"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 0.5 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000695. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000695"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000480">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000480"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Annual escapement count</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000480. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000480"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0100001">
+    <rdfs:label>term replaced by</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000492">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000492"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Commercial harvest count</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000492. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000492"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000671">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000671"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Fish stock code</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000671. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000671"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000780">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000780"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>AWC water body code</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000780. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000780"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000582">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000582"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Cutthroat trout</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000582. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000582"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000186">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000186"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Fish sex determination method</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000186. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000186"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000142">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000142"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Fishing gear type</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000142. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000142"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000243">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000243"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Coho salmon</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000243. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000243"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000235">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000235"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Distance between scale circuli</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000235. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000235"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000239">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000239"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Chinook salmon</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000239. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000239"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000727">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000727"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 4.1 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000727. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000727"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000755">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000755"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 8.x recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000755. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000755"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SALMON_alignment_">
+    <owl:versionInfo>0.1</owl:versionInfo>
+    <rdfs:label>Alignment ontology for The Salmon Ontology (SALMON)</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
+    <j.2:GitRepository rdf:resource="https://github.com/DataONEorg/sem-prov-ontologies"/>
+    <j.0:license rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
+    <j.0:creator rdf:resource="https://orcid.org/0000-0002-0381-3766"/>
+    <dc:description>This ontology contains a set of classes (and their alignments) for deprecated terms from The Salmon Ontology (SALMON). While patterns for deprecating terms in ontologies commonly involve retaining the deprecated term(s) in the main ontology, we've opted to move the deprecated terms into an alignment ontology. Our main justification for this choice is (1) that all publicly-accessible instances of deprecated terms were created before the first published release of SALMON and (2) we have sufficient authorship access to update these instances to use published terms.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-07-18</dc:date>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000711">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000711"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 2.3 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000711. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000711"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000666">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000666"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 2.x recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000666. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000666"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000698">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000698"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 1.3 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000698. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000698"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000642">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000642"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Rainbow trout</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000642. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000642"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000630">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000630"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Fish length determination method</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000630. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000630"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000783">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000783"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Subsistence fishery harvest count</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000783. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000783"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000694">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000694"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 0.4 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000694. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000694"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000670">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000670"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 6.x recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000670. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000670"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000242">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000242"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Sockeye salmon</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000242. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000242"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000133">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000133"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Mid-orbit to fork of tail length</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000133. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000133"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000189">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000189"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Saltwater age</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000189. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000189"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000525">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000525"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>ADF&amp;G species code</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000525. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000525"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000569">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000569"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Dolly Varden trout</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000569. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000569"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000129">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000129"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Post-orbit to fork of tail length</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000129. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000129"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000529">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000529"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Fish sample code</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000529. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000529"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000719">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000719"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 3.2 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000719. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000719"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000718">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000718"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 3.1 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000718. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000718"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000669">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000669"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 5.x recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000669. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000669"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000754">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000754"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 7.x recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000754. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000754"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000710">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000710"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 2.2 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000710. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000710"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000665">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000665"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 1.x recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000665. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000665"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000697">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000697"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 1.2 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000697. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000697"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000782">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000782"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Recruits per spawner</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000782. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000782"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000240">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000240"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Chum salmon</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000240. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000240"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000693">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000693"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 0.3 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000693. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000693"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000681">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000681"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age error code</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000681. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000681"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000680">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000680"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Gum card number</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000680. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000680"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000241">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000241"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Pink salmon</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000241. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000241"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000188">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000188"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Freshwater age</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000188. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000188"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000132">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000132"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Mid-orbit to posterior insertion of anal fin length</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000132. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000132"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000520">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000520"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Brood year</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000520. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000520"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000128">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000128"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Fork length</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000128. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000128"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000504">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000504"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Salmon abundance</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000504. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000504"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000729">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000729"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 4.3 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000729. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000729"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000705">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000705"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 0.6 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000705. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000705"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000713">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000713"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 2.5 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000713. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000713"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000668">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000668"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 4.x recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000668. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000668"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000701">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000701"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 1.6 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000701. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000701"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000777">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000777"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Girth of fish</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000777. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000777"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000721">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000721"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 3.4 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000721. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000721"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000785">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000785"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Sport fishery harvest count</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000785. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000785"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000696">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000696"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 1.1 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000696. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000696"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000130">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000130"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Post orbit to hypural plate length</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000130. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000130"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000481">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000481"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Daily escapement count</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000481. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000481"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000570">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000570"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Steelhead trout</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000570. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000570"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000493">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000493"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Fish biomass</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000493. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000493"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000692">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000692"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 0.2 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000692. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000692"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000187">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000187"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Total age</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000187. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000187"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000691">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000691"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 0.1 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000691. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000691"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000200">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000200"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Fish age (European notation)</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000200. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000200"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000131">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000131"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Mid-orbit to hypural plate length</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000131. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000131"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000127">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000127"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Fish length measurement type</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000127. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000127"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000216">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000216"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Fish sex measurement type</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000216. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000216"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000527">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000527"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>ADF&amp;G gear code</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000527. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000527"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/salmon_000709">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SALMON_00000709"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label>Age class 2.1 recruits</rdfs:label>
+    <rdfs:comment>This term is deprecated in favor of http://purl.dataone.org/odo/SALMON_00000709. Existing uses should be updated where possible.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <j.1:IAO_0100001 rdf:resource="http://purl.dataone.org/odo/SALMON_00000709"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/src/main/resources/ontologies/SASAP.owl
+++ b/src/main/resources/ontologies/SASAP.owl
@@ -1,0 +1,3592 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:j.0="http://purl.org/dc/terms/"
+    xmlns:j.1="https://schema.org/"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:j.2="http://www.geneontology.org/formats/oboInOwl#"
+    xmlns:j.3="http://www.w3.org/2004/02/skos/core#"
+    xmlns:j.4="http://usefulinc.com/ns/doap#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:j.5="http://purl.dataone.org/odo/"
+    xmlns="http://purl.dataone.org/odo/SASAP_"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#" > 
+  <rdf:Description rdf:nodeID="A0">
+    <dc:source>https://knb.ecoinformatics.org/portals/SASAP/Regions#arctic
+https://knb.ecoinformatics.org/view/doi%3A10.5063%2FF1WH2N8W</dc:source>
+    <owl:annotatedTarget>In the Arctic region of Alaska, connections between salmon and people are in their infancy. Salmon are just one harbinger of change in this region.
+
+The bounding coordinates for this SASAP region are:
+North: 71.4396 degrees
+South: 67.7408 degrees
+East: -136.684 degrees
+West: -166.311 degrees</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000003"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/source">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A1">
+    <j.2:hasDbXref>http://www.adfg.alaska.gov/index.cfm?adfg=divisions.sfmission</j.2:hasDbXref>
+    <owl:annotatedTarget>A department within the government of Alaska with a mission to protect and improve the state's sport fishery resources.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000035"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000054">
+    <j.3:altLabel>Working Group</j.3:altLabel>
+    <rdfs:label xml:lang="en">SASAP working group and project support</rdfs:label>
+    <dc:description>Beginning in 2016, nine SASAP working groups formed – each composed of between 12 and 24 knowledge experts from a range of disciplines, backgrounds, and regions. Each participant brought his or her data and experiences for synthesis and analysis, while NCEAS provided logistical and technical support to facilitate each group’s innovative work.
+
+Each of the nine groups focused on specific issues related to salmon and people in Alaska:
+
+Four SASAP groups were tasked with integrating knowledge across multiple disciplines to understand the fundamental state of knowledge of Alaska’s salmon systems. The work of each group is presented for each of the major watersheds in Alaska in the Region section (https://alaskasalmonandpeople.org/regions/).
+
+An additional five working groups were selected to focus on specific research questions that provide insight into the pressures on salmon and salmon communities, as well as options for response to those pressures. Their work is presented in the Special Topics section (https://alaskasalmonandpeople.org/topics/).</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:45:38Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000284">
+    <rdfs:label xml:lang="en">Greg Roscicza</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:49:34Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000050"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000066">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <j.3:closeMatch>https://schema.org/affiliation</j.3:closeMatch>
+    <owl:inverseOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000069"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T19:00:26Z</dc:date>
+    <j.3:definition>An organization that this person is affiliated with. For example, a school/university, a club, or a team.</j.3:definition>
+    <rdfs:range rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <rdfs:label xml:lang="en">isAffiliateOf</rdfs:label>
+    <dc:description>The SASAP project and its associated working groups were made up of researchers from a variety of academic, govenmental, etc. organizations from across the United States. The 'affiliateOf' object property connects SASAP researchers with their respective employer(s)/home institution(s) (at least what was considered to be their employer/home institution during the time when they worked on the SASAP project).</dc:description>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:domain rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000272">
+    <rdfs:label xml:lang="en">Matthew Catalano</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:32:36Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000346"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000393">
+    <rdfs:label xml:lang="en">American-based college or university</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T17:33:35Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000174"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000078">
+    <owl:sameAs>https://orcid.org/0000-0002-4244-2865</owl:sameAs>
+    <rdfs:label xml:lang="en">Jorge Cornejo-Donoso</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:08:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000103"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000100"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000260">
+    <rdfs:label xml:lang="en">Erika Gavenus</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-19T23:48:58Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000056"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000337"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000381">
+    <j.3:altLabel>UC Berkeley
+Berkeley</j.3:altLabel>
+    <owl:sameAs>https://ror.org/01an7q238</owl:sameAs>
+    <rdfs:label xml:lang="en">University of California, Berkeley</rdfs:label>
+    <dc:description>UC Berkeley's website is accessible at: https://www.berkeley.edu/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T16:38:19Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000393"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000030">
+    <j.3:definition>A department within the government of Alaska which manages commercial, subsistence, and personal use fisheries within the jurisdiction of the State of Alaska.</j.3:definition>
+    <rdfs:label xml:lang="en">Alaska Department of Fish and Game, Division of Commercial Fisheries</rdfs:label>
+    <dc:description>The Division of Commercial Fisheries website is accessible at: https://www.adfg.alaska.gov/index.cfm?adfg=fishingcommercial.main</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:03:36Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000028"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000042">
+    <j.3:definition>A community-based nonprofit organization that combines advocacy, education and science toward its mission to protect Alaska’s Cook Inlet watershed and the life it sustains. Inletkeeper’s monitoring and science work builds credibility with scientists and resource managers, its education and advocacy efforts enhance stewardship and citizen participation, and together, these efforts translate into Inletkeeper’s ability to effectively ensure a vibrant and healthy Cook Inlet watershed.</j.3:definition>
+    <rdfs:label xml:lang="en">Cook Inletkeeper</rdfs:label>
+    <dc:description>The Cook Inletkeeper's website is accessible at: https://inletkeeper.org/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:04:51Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000026"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000296">
+    <owl:sameAs>https://orcid.org/0000-0002-6689-9392</owl:sameAs>
+    <rdfs:label xml:lang="en">Madeline Javonovich</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:09:17Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000059"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000113"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A2">
+    <dc:source>https://en.wikipedia.org/wiki/North_Slope_Borough,_Alaska
+https://www.wikidata.org/wiki/Q511806</dc:source>
+    <owl:annotatedTarget>The North Slope Borough is the northernmost borough in the US state of Alaska.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000369"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A3">
+    <rdf:rest rdf:nodeID="A4"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A5">
+    <rdf:rest rdf:nodeID="A6"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000054"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/date">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000065">
+    <rdfs:label xml:lang="en">Peter Westley</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:58:18Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000059"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000055"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000113"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000174">
+    <j.3:exactMatch rdf:resource="http://vivoweb.org/ontology/core#University"/>
+    <j.3:definition>An institution of higher education and research, which grants academic degrees in a variety of subjects, and provides both undergraduate education and postgraduate education.</j.3:definition>
+    <rdfs:label xml:lang="en">College or university</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-02T20:22:02Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <owl:equivalentClass rdf:resource="http://vivoweb.org/ontology/core#University"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000295">
+    <owl:sameAs>https://orcid.org/0000-0002-5415-3534</owl:sameAs>
+    <rdfs:label xml:lang="en">Krista Oke</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:08:39Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000059"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000113"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000077">
+    <owl:sameAs>https://orcid.org/0000-0003-4703-1974</owl:sameAs>
+    <rdfs:label xml:lang="en">Jeanette Clark</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:08:02Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000103"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000100"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000283">
+    <rdfs:label xml:lang="en">Lamont Albertson</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:48:56Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000357"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000089">
+    <owl:sameAs>https://orcid.org/0000-0002-0258-9264</owl:sameAs>
+    <rdfs:label xml:lang="en">Kristen B. Gorman</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:09:26Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000110"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000271">
+    <rdfs:label xml:lang="en">Lewis Coggins</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:29:14Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000045"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000392">
+    <j.3:altLabel>McGill</j.3:altLabel>
+    <owl:sameAs>https://ror.org/01pxwe438</owl:sameAs>
+    <rdfs:label xml:lang="en">McGill University</rdfs:label>
+    <dc:description>McGill University's website is accessible at: https://www.mcgill.ca/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T17:32:35Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000394"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000380">
+    <j.3:altLabel>UCSC</j.3:altLabel>
+    <owl:sameAs>https://ror.org/03s65by71</owl:sameAs>
+    <rdfs:label xml:lang="en">University of California, Santa Cruz</rdfs:label>
+    <dc:description>UCSC's website is accessible at: https://www.ucsc.edu/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T16:34:58Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000393"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A7">
+    <j.2:hasDbXref>https://www.fws.gov/</j.2:hasDbXref>
+    <owl:annotatedTarget>A bureau of the United States Department of the Interior whose mission is to work with others to conserve, protect and enhance fish, wildlife and plants and their habitats for the continuing benefit of the American people.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000045"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000041">
+    <j.3:definition>A department within the government of Alaska which provides non-partisan budgetary and fiscal analysis to the Alaska Legislature.</j.3:definition>
+    <j.3:altLabel>LFD</j.3:altLabel>
+    <rdfs:label xml:lang="en">Alaska Department of Legislative Finance</rdfs:label>
+    <dc:description>LFD's webpage is accessible at: https://www.legfin.akleg.gov/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:04:43Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A8">
+    <rdf:rest rdf:nodeID="A9"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000054"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A10">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000389"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A11">
+    <dc:source>https://www.nhgis.org/</dc:source>
+    <owl:annotatedTarget>The National Historical Geographic Information System (NHGIS) provides easy access to summary tables and time series of population, housing, agriculture, and economic data, along with GIS-compatible boundary files, for years from 1790 through the present and for all levels of U.S. census geography, including states, counties, tracts, and blocks.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000181"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000262">
+    <owl:sameAs>https://orcid.org/0000-0001-5923-4133</owl:sameAs>
+    <rdfs:label xml:lang="en">Patricial M. Clay</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-19T23:53:46Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000056"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000338"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000383">
+    <j.3:altLabel>UBC</j.3:altLabel>
+    <owl:sameAs>https://ror.org/03rmrcq20</owl:sameAs>
+    <rdfs:label xml:lang="en">The University of British Columbia</rdfs:label>
+    <dc:description>UBC's website is accessible at: https://www.ubc.ca/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T16:40:45Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000394"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000032">
+    <j.3:definition>A department within the government of Alaska and a sub-division of the Alaska Department of Fish and Wildlife, Division of Commercial Fisheries which manages the Central Region.</j.3:definition>
+    <rdfs:label xml:lang="en">Alaska Department of Fish and Game, Division of Commercial Fisheries, Central Region</rdfs:label>
+    <dc:description>Central Region Alaska commercial fisheries are composed of four distinct management areas that include Bristol Bay, Prince William Sound and Copper River, Upper Cook Inlet, and Lower Cook Inlet. Although all 5 species of salmon are harvested in each area, sockeye and pink salmon are the most abundant and most valuable. This area encompasses some of the largest and most valuable salmon fisheries in the world. From Bristol Bay, home of the largest sockeye salmon fishery in the world, to the Copper River where sockeye and Chinook salmon fetch some of the highest prices per pound paid to commercial fishermen. Cook Inlet commercial fisheries occur near the largest population center in Alaska, providing salmon to numerous niche and local markets, as well as fresh salmon to markets in other states. Prince William Sound adds productive healthy pink, chum, and sockeye salmon fisheries to the region. Southcentral groundfish fisheries are small, yet diverse, targeting pollock, Pacific cod, rockfish, sablefish, lingcod, and skate while small shrimp and scallop fisheries in Prince William Sound cater predominately to local markets. Southcentral commercial fisheries are of tremendous importance and an integral part of many communities and local economies in the state.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:04:02Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000028"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000371">
+    <j.3:altLabel>DFO</j.3:altLabel>
+    <rdfs:label xml:lang="en">Fisheries and Oceans Canada</rdfs:label>
+    <dc:description>DFO's website is accessible at: https://www.dfo-mpo.gc.ca/index-eng.html</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T23:04:01Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000025"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000044">
+    <j.3:exactMatch>https://ror.org/01qn7cs15</j.3:exactMatch>
+    <j.3:definition>A principle agency of the U.S. Federal Satistical System, whose responsibility and mission is to serve as the nation's leading provider of quality data about its people and economy.</j.3:definition>
+    <rdfs:label xml:lang="en">United States Census Bureau</rdfs:label>
+    <dc:description>The U.S. Census Bureau's website is accessible at: https://www.census.gov/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:05:22Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000025"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000056">
+    <j.3:altLabel>Sociocultural working group</j.3:altLabel>
+    <rdfs:label xml:lang="en">Social and cultural dimensions of salmon systems working group</rdfs:label>
+    <rdfs:comment>Learn more about the Social and Cultural Dimensions of Salmon Systems Working Group here: https://alaskasalmonandpeople.org/working-group/social-and-cultural-dimensions-of-salmon-systems/</rdfs:comment>
+    <dc:description>The topics explored by the Sociocultural working group are (1) social and cultural values and relationships between people and salmon, (2) trends in human populations and communities and uses of salmon, and (3) key threads to salmon-dependent communities</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:47:05Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000054"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000068">
+    <rdfs:label xml:lang="en">Dan Rinella</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T19:07:18Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000055"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000045"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A12">
+    <rdf:rest rdf:nodeID="A13"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000178"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A14">
+    <j.2:hasDbXref>https://alaskasalmonandpeople.org/about/process-people/</j.2:hasDbXref>
+    <owl:annotatedTarget>A research center of the University of California, Santa Barbara which fosters collaborative synthesis research by assembling interdisciplinary teams to distill existing data, ideas, theories, or methods drawn from many sources, across multiple fields of inquiry, in order to accelerate the generation of new knowledge on a broad scale.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000100"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000298">
+    <rdfs:label xml:lang="en">Steve Munch</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:11:15Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000059"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000338"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000286">
+    <rdfs:label xml:lang="en">Kevin Whitworth</rdfs:label>
+    <rdfs:comment>The SASAP website lists Kevin Whitworth's affiliation as 'Up-River Stakeholder', but I've been unable to find information about that online to include as an 'Organization' instance.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:50:25Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000274">
+    <rdfs:label xml:lang="en">Steve Fleischman</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:34:26Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000028"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000395">
+    <j.3:altLabel>McGill Biology</j.3:altLabel>
+    <rdfs:label xml:lang="en">Department of Biology</rdfs:label>
+    <dc:description>McGill's Department of Biology's website is accessible at: https://www.mcgill.ca/biology/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T17:36:24Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000392"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000207"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A15">
+    <dc:source>https://knb.ecoinformatics.org/portals/SASAP/Regions#kotzebue
+https://knb.ecoinformatics.org/view/doi%3A10.5063%2FF1WH2N8W</dc:source>
+    <owl:annotatedTarget>Straddling the Arctic Circle, the Kotzebue region is twice the size of West Virginia and categorized as among the driest areas of Alaska. Chum salmon is the primary species in this region and is harvested by local users in both subsistence and commercial fisheries.
+
+The bounding coordinates for this SASAP region are:
+North: 68.9178 degrees
+South: 65.3082 degrees
+East: 65.3082 degrees
+West: -169.0513 degrees</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000009"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000043">
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:04:57Z</dc:date>
+    <rdfs:label xml:lang="en">National Park Service</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <j.3:definition>An agency of the federal government of the United States that manages all national parks, many national monuments, and other conservation and hisotrical properties with various title designations.</j.3:definition>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000025"/>
+    <dc:description>Visit the National Park Service's website at: https://www.nps.gov/index.htm</dc:description>
+    <j.3:altLabel>NPS</j.3:altLabel>
+    <j.3:exactMatch>https://ror.org/044zqqy65</j.3:exactMatch>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000273">
+    <owl:sameAs>https://orcid.org/0000-0002-2342-3482</owl:sameAs>
+    <rdfs:label xml:lang="en">Ben Staton</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:33:36Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000394">
+    <rdfs:label xml:lang="en">Canadian-based college or university</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T17:33:46Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000174"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A16">
+    <j.2:hasDbXref>http://dnr.alaska.gov/ssd/irm/</j.2:hasDbXref>
+    <owl:annotatedTarget>A division within the government of Alaska's Department of Natural Resources (DNR) which maintains the department's land records repository and oversees DNR's computer systems and networks services. It provides for the department's data processing functions including development, training, operations, and maintenance. The Department of Natural Resources' (DNR) systems include the Land Administration System (LAS), the Geographic Information System, the Revenue and Billing System, and others. The section also produces and maintains the state's land status maps.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000039"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000055">
+    <rdfs:label xml:lang="en">Biophysical working group</rdfs:label>
+    <rdfs:comment>Learn more about the Biophysical Working Group here: https://alaskasalmonandpeople.org/working-group/biophysical-information-on-salmon-distribution-and-habitat/</rdfs:comment>
+    <dc:description>The goal of the to Biophysical working group is to compare and contrast the status of Alaska salmon and their habitats across regions.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:46:55Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000054"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000261">
+    <rdfs:label xml:lang="en">Caroline Brown</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-19T23:51:22Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000056"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000028"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000382">
+    <j.3:altLabel>MSU</j.3:altLabel>
+    <owl:sameAs>https://ror.org/05hs6h993</owl:sameAs>
+    <rdfs:label xml:lang="en">Michigan State University</rdfs:label>
+    <dc:description>MSU's website is accessible at: https://msu.edu/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T16:39:46Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000393"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000067">
+    <rdfs:label xml:lang="en">isLeadResearcherOf</rdfs:label>
+    <dc:description>Each SASAP working group has an affiliated researcher(s) leading the working group's research efforts. The 'isLeadResearcherOf' object property connects lead researchers to their respective working groups.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T19:00:44Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:range rdf:nodeID="A17"/>
+    <rdfs:domain rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <owl:inverseOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000071"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A18">
+    <j.2:hasDbXref>http://www.adfg.alaska.gov/index.cfm?adfg=divisions.sfmission</j.2:hasDbXref>
+    <owl:annotatedTarget>The Division of Sport Fisheries provides the following core services: (a) fisheries management, (b) fisheries research, (c) fisheries enhancement, (d) protection and restoration of fish habitats for the ebefit of fish and sport anglers, (e) communication and outreach, and (f) providing leadership and administrative support for the Division's core functions.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000035"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000370">
+    <rdfs:label xml:lang="en">NOAA Fisheries Northwest Fisheries Science Center</rdfs:label>
+    <dc:description>NOAA Fisheries Northwest Fisheries Science Center's website is accessible at: https://www.fisheries.noaa.gov/about/northwest-fisheries-science-center</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T22:59:58Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000351"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000025"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000079">
+    <owl:sameAs>https://orcid.org/0000-0002-1513-9078</owl:sameAs>
+    <rdfs:label xml:lang="en">Courtney Carothers</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:08:16Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000056"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000113"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A19">
+    <rdf:rest rdf:nodeID="A20"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000297">
+    <rdfs:label xml:lang="en">Neala Kendall</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:10:15Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000059"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000047"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000031">
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <j.3:definition>A department within the government of Alaska and a sub-division of the Alaska Department of Fish and Wildlife, Division of Commercial Fisheries which manages the Arctic-Yukon-Kuskokwim Region.</j.3:definition>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:03:57Z</dc:date>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:label xml:lang="en">Alaska Department of Fish and Game, Division of Commercial Fisheries, Arctic-Yukon-Kuskokwim Region</rdfs:label>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000028"/>
+    <j.3:altLabel>AYK</j.3:altLabel>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <dc:description>The Arctic-Yukon-Kuskokwim (AYK) Region encompasses the coastal waters of Alaska and includes the rivers and streams that drain into the Bering, Chukchi, and Beaufort Seas. It stretches from its boundary at Cape Newenham with the Bristol Bay area to the border with Canada on the Arctic Ocean. The Yukon River, with the fifth largest drainage in North America, lies within this management region, as do many other major rivers; the Kuskokwim being second in size next to the Yukon. With the exception of Fairbanks, Bethel, and Nome, this is a region of villages. Salmon and herring are the most important fisheries resources in this region. Large numbers of salmon are taken for subsistence and subsistence harvests can equal or surpass the numbers of fish harvested in commercial fisheries, especially Chinook salmon. King crab is harvested near Nome in both commercial and subsistence fisheries. Whitefish are also important to the residents of this region.</dc:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000285">
+    <rdfs:label xml:lang="en">Nick Kameroff</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:50:03Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000358"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A21">
+    <j.2:hasDbXref>http://nativecouncil.org/welcome/</j.2:hasDbXref>
+    <owl:annotatedTarget>A federally recognized governing body for the community of Bethel, Alaska whose mission is to promote the general welfare, enhance independence, encourage self-sufficiency/self-motivation, enhance quality of life, and preserve cultural and traditional values of the Tribe, and to exercise tribal authority over resources through educational, economic, and social development opportunities.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000050"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000098">
+    <j.3:exactMatch rdf:resource="https://schema.org/Organization"/>
+    <rdfs:label xml:lang="en">Organization</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T21:14:05Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000183">
+    <j.3:altLabel>Consulting firm</j.3:altLabel>
+    <rdfs:label xml:lang="en">Consultancy</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-06T17:24:47Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000292">
+    <rdfs:label xml:lang="en">Holly Kindsvter</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:55:31Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000059"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000356"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://rs.tdwg.org/dwc/terms/originalNameUsage">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000280">
+    <rdfs:label xml:lang="en">Zach Liller</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:46:53Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000028"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000050">
+    <j.3:definition>A federally recognized governing body for the community of Bethel, Alaska whose mission is to promote the general welfare, enhance independence, encourage self-sufficiency/self-motivation, enhance quality of life, and preserve cultural and traditional values of the Tribe, and to exercise tribal authority over resources through educational, economic, and social development opportunities.</j.3:definition>
+    <j.3:altLabel>ONC</j.3:altLabel>
+    <rdfs:label xml:lang="en">Orutsararmiut Traditional Native Council</rdfs:label>
+    <dc:description>The ONC website is accessible at: http://nativecouncil.org/welcome/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:06:45Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000097"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000062">
+    <rdfs:label xml:lang="en">Kenai lowlands working group</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:47:37Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000054"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000074">
+    <owl:sameAs>https://orcid.org/0000-0001-5722-5073</owl:sameAs>
+    <rdfs:label xml:lang="en">Ian Dutton</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:07:45Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000122"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000103"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000118"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000086">
+    <rdfs:label xml:lang="en">Rachel Donkersloot</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:09:04Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000056"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000111"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A22">
+    <rdf:rest rdf:nodeID="A10"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000207"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/description">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000291">
+    <owl:sameAs>https://orcid.org/0000-0002-4807-6667</owl:sameAs>
+    <rdfs:label xml:lang="en">Andrew P. Hendry</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:54:54Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000059"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000395"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000391"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000061">
+    <j.3:altLabel>Community engagement working group
+Community based monitoring working group</j.3:altLabel>
+    <rdfs:label>Comunity monitoring working group</rdfs:label>
+    <rdfs:label xml:lang="en">Community based monitoring working group</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:47:30Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000054"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000085">
+    <owl:sameAs>https://orcid.org/0000-0002-5496-7263</owl:sameAs>
+    <rdfs:label xml:lang="en">Eric P. Palkovacs</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:08:54Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000059"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000114"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000097">
+    <rdfs:label xml:lang="en">Indigenous-led organization</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T21:04:36Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A23">
+    <dc:source>http://en.wikipedia.org/wiki/Kodiak_Island
+https://www.wikidata.org/wiki/Q514093</dc:source>
+    <owl:annotatedTarget>A large island on the south coast of the State of Alaska, separated from the Alaska mainland by the Shelikof Strait.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000008"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A24">
+    <rdf:rest rdf:nodeID="A22"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000178"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A25">
+    <dc:source>https://alaskasalmonandpeople.org/about/process-people/</dc:source>
+    <owl:annotatedTarget>An essential component of the SASAP working group process is the support each group received from a stellar group of “data wranglers”, a team of geospatial analysis experts from NCEAS known as the Data Task Force.
+
+The Task Force coordinated hundreds of data requests from Alaska Department of Fish and Game and other agencies and organizations, then worked to reformat, integrate, and run quality control on millions of lines of data in over 125 data sets.
+
+The graphs, figures, and infograms generated by the Task Force greatly enhanced the ability of users to visualize often complex information about Alaska salmon.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000103"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.geneontology.org/formats/oboInOwl#hasDbXref">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000076">
+    <owl:sameAs>https://orcid.org/0000-0001-8874-7595</owl:sameAs>
+    <rdfs:label xml:lang="en">Jared Kibele</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:07:56Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000103"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000100"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000088">
+    <rdfs:label xml:lang="en">Robert W. Campbell</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:09:14Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000110"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000294">
+    <owl:sameAs>https://orcid.org/0000-0002-8900-9479</owl:sameAs>
+    <rdfs:label xml:lang="en">Katie Kobayashi</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:07:08Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000059"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000114"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000282">
+    <rdfs:label xml:lang="en">Stephanie Quinn-Davidson</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:48:32Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000340"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A26">
+    <rdf:rest rdf:nodeID="A27"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000391">
+    <rdfs:label xml:lang="en">Redpath Museum</rdfs:label>
+    <dc:description>The Redpath Museum's website is accessible at: https://www.mcgill.ca/redpath/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T17:31:49Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000392"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000389"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A28">
+    <dc:source>http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C54073</dc:source>
+    <owl:annotatedTarget>An organization whose primary objective is to support some issue or matter of private interest or public concern for non-commercial purposes. Nonprofits generally do not operate to generate profit, and this characteristic is popularly considered to be the defining characterisitic of such organizations. However, a non-profit organization may accept, hold and disburse money and other things of value. It may also legally and ethically trade at a profit. The extent to which it can generate income may be constrained, or the use of those profits may be restricted.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000026"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A29">
+    <j.2:hasDbXref>http://www.adfg.alaska.gov/index.cfm?adfg=about.cfec#:~:text=Department%20of%20Fish%20and%20Game%3B%20Commercial%20Fisheries%20Entry%20Commission,the%20number%20of%20participating%20fishers.</j.2:hasDbXref>
+    <owl:annotatedTarget>A department within the government of Alaska which helps to conserve and maintain the economic health of Alaska’s commercial fisheries by limiting the number of participating fishers. The Commission issues permits and vessel licenses to qualified individuals in both limited and unlimited fisheries, and provides due process hearings and appeal processes for disputes related to limitations on fishery participation.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000029"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000040">
+    <j.3:definition>A division wihtin Alaska's Department of Public Safety with a mission to  protect Alaska's Natural Resources through the enfrocement wildlife statutes and regulations.</j.3:definition>
+    <j.3:altLabel>AWT</j.3:altLabel>
+    <rdfs:label xml:lang="en">Alaska Department of Public Safety, Division of Alaska Wildlife Troopers</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:04:39Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000064">
+    <j.3:exactMatch rdf:resource="https://schema.org/Person"/>
+    <rdfs:label xml:lang="en">Person</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:48:44Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A30">
+    <rdfs:comment>This URI does not appear to dereference to the term. Including this URL, https://bioportal.bioontology.org/ontologies/NCIT?p=classes&amp;conceptid=http%3A%2F%2Fncicb.nci.nih.gov%2Fxml%2Fowl%2FEVS%2FThesaurus.owl%23C54073, to ensure findability.</rdfs:comment>
+    <owl:annotatedTarget rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C54073"/>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#exactMatch"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000026"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A31">
+    <dc:source>https://knb.ecoinformatics.org/portals/SASAP/About</dc:source>
+    <owl:annotatedTarget>The State of Alaska's Salmon and People (SASAP) project is a collaboration of researchers, cultural leaders, and others working to bring together integrated, accurate, and up-to-date information that will help to support better salmon decision-making.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000087">
+    <rdfs:label xml:lang="en">Peter S. Rand</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:09:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000110"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000293">
+    <rdfs:label xml:lang="en">John Reynolds</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:06:12Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000059"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000355"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000281">
+    <rdfs:label xml:lang="en">Nick Smith</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:47:30Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000028"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000390">
+    <j.3:altLabel>Smithsonian
+SI</j.3:altLabel>
+    <rdfs:label xml:lang="en">Smithsonian Institution</rdfs:label>
+    <dc:description>The Smithsonian's website is accessible at: https://www.si.edu/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T17:30:23Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000389"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A32">
+    <dc:source>https://www.adfg.alaska.gov/index.cfm?adfg=fishingcommercialbyarea.interior</dc:source>
+    <owl:annotatedTarget>The Arctic-Yukon-Kuskokwim (AYK) Region encompasses the coastal waters of Alaska and includes the rivers and streams that drain into the Bering, Chukchi, and Beaufort Seas. It stretches from its boundary at Cape Newenham with the Bristol Bay area to the border with Canada on the Arctic Ocean. The Yukon River, with the fifth largest drainage in North America, lies within this management region, as do many other major rivers; the Kuskokwim being second in size next to the Yukon. With the exception of Fairbanks, Bethel, and Nome, this is a region of villages. Salmon and herring are the most important fisheries resources in this region. Large numbers of salmon are taken for subsistence and subsistence harvests can equal or surpass the numbers of fish harvested in commercial fisheries, especially Chinook salmon. King crab is harvested near Nome in both commercial and subsistence fisheries. Whitefish are also important to the residents of this region.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000031"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A33">
+    <j.2:hasDbXref>https://en.wikipedia.org/wiki/National_Park_Service</j.2:hasDbXref>
+    <owl:annotatedTarget>An agency of the federal government of the United States that manages all national parks, many national monuments, and other conservation and hisotrical properties with various title designations.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000043"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A34">
+    <j.2:hasDbXref>https://en.wikipedia.org/wiki/Intergovernmental_organization
+https://www.wikidata.org/wiki/Q245065</j.2:hasDbXref>
+    <dc:source>https://hls.harvard.edu/dept/opia/what-is-public-interest-law/public-service-practice-settings/public-international-law/intergovernmental-organizations-igos/</dc:source>
+    <owl:annotatedTarget>An entity created by treaty, involving two or more nations, to work in good faith, on issues of common interest.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000048"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000063">
+    <j.3:altLabel>Well-being working group</j.3:altLabel>
+    <rdfs:label xml:lang="en">Well-being and salmon systems working group</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:47:41Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000054"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000075">
+    <owl:sameAs>https://orcid.org/0000-0003-0077-4738</owl:sameAs>
+    <rdfs:label xml:lang="en">Matthew Jones</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:07:50Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000103"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000100"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A35">
+    <owl:unionOf rdf:nodeID="A3"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A36">
+    <dc:source>https://schema.org/Project</dc:source>
+    <owl:annotatedTarget>An enterprise (potentially individual but typically collaborative), planned to achieve a particular aim.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000121"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://vivoweb.org/ontology/core#University">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A37">
+    <dc:source>http://en.wikipedia.org/wiki/Bristol_Bay
+https://www.wikidata.org/wiki/Q917872</dc:source>
+    <owl:annotatedTarget>The eastern-most arm of the Bering Sea. It is located between the southwest part of the Alaska mainland to its north, and the Alaska Peninsula to its south and east. Bristol Bay is 400 km long and 290 km wide at its mouth. A number of rivers flow into the bay, including the Cinder, Igushik, Kvichak, Meshik, Nushagak, Naknek, Togiak, and Ugashik.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000004"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A13">
+    <rdf:rest rdf:nodeID="A38"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000207"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A39">
+    <j.2:hasDbXref>http://www.adfg.alaska.gov/index.cfm?adfg=divisions.subsoverview</j.2:hasDbXref>
+    <owl:annotatedTarget>A department within the government of Alaska with a mission to scientifically gather, quantify, evaluate, and report information about customary and traditional uses of Alaska's fish and wildlife resources.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000036"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A40">
+    <j.2:hasDbXref>https://en.wikipedia.org/wiki/Category:Independent_research_institutes#:~:text=From%20Wikipedia%2C%20the%20free%20encyclopedia,operate%20under%20their%20own%20authority.</j.2:hasDbXref>
+    <owl:annotatedTarget>A research institute which is not part of a university, government, hospital or corporation. An independent research institute may have a close relationship with a larger institution such as a university, but is not part of the larger insitution and operates under its own authority.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000178"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A17">
+    <owl:unionOf rdf:nodeID="A41"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000082">
+    <rdfs:label xml:lang="en">Steven J. Langdon</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:08:34Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000058"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000115"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000094">
+    <owl:sameAs>https://orcid.org/0000-0001-8384-3385</owl:sameAs>
+    <rdfs:label xml:lang="en">Charles A. Simenstad</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:09:56Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000107"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000309">
+    <rdfs:label xml:lang="en">Willy Dunne</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:21:59Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000378"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000081">
+    <rdfs:label xml:lang="en">Tobias Schworer</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:08:28Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000057"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000117"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000093">
+    <owl:sameAs>https://orcid.org/0000-0002-8103-475X</owl:sameAs>
+    <rdfs:label xml:lang="en">Mark Rains</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:09:48Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000106"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A9">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000121"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000409">
+    <j.3:exactMatch rdf:resource="http://purl.org/dc/elements/1.1/contributor"/>
+    <rdfs:label xml:lang="en">contributedDataTo</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-22T03:47:22Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:range rdf:resource="http://purl.dataone.org/odo/SASAP_00000101"/>
+    <rdfs:domain rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <owl:inverseOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000410"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A42">
+    <rdfs:comment>Using skos:closeMatch rather than skos:exactMatch because schema.org does not provide an inverse property to https://schema.org/affiliation. We define the inverse of 'affiliateOf' as 'hasAffiliate'.</rdfs:comment>
+    <owl:annotatedTarget>https://schema.org/affiliation</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#closeMatch"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000066"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A43">
+    <dc:source>http://en.wikipedia.org/wiki/Alaska_panhandle
+https://www.wikidata.org/wiki/Q198710</dc:source>
+    <owl:annotatedTarget>The southeastern portion of the coast of the State of Alaska, which lies just west of the northern half of the Canadian province of British Columbia. The majority of the panhandle's area is part of the Tongass National Forest, the United States's largest national forest. In many places, the international border runs along the crest of the Boundary Ranges of the Coast Mountains.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000013"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A44">
+    <owl:unionOf rdf:nodeID="A45"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A46">
+    <dc:source>https://knb.ecoinformatics.org/portals/SASAP/Regions#yukon
+https://knb.ecoinformatics.org/view/doi%3A10.5063%2FF1WH2N8W</dc:source>
+    <owl:annotatedTarget>Larger than the state of Texas and home to the third longest river in the United States, the Yukon region is a governance mosaic of state and federal fisheries management.
+
+The bounding coordinates for this SASAP region are:
+North: 69.0792 degrees
+South: 58.8686 degrees
+East: -129.1775 degrees
+West: -166.281 degrees</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000014"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A47">
+    <dc:source>http://en.wikipedia.org/wiki/Alaska_Peninsula
+https://www.wikidata.org/wiki/Q119285</dc:source>
+    <owl:annotatedTarget>A peninsula extending about 800 km to the southwest from the mainland of Alaska and ending in the Aleutian Islands. The peninsula separates the Pacific Ocean from Bristol Bay, an arm of the Bering Sea.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000002"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A48">
+    <dc:source>http://en.wikipedia.org/wiki/Norton_Sound
+https://www.wikidata.org/wiki/Q1973692</dc:source>
+    <owl:annotatedTarget>An inlet of the Bering Sea on the western coast of the State of Alaska, south of the Seward Peninsula. It is about 240 km long and 200 km wide. The Yukon River delta forms a portion of the south shore and water from the Yukon influences this body of water.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000012"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000181">
+    <dc:description>The National Historical Geographic Information System (NHGIS) provides easy access to summary tables and time series of population, housing, agriculture, and economic data, along with GIS-compatible boundary files, for years from 1790 through the present and for all levels of U.S. census geography, including states, counties, tracts, and blocks.</dc:description>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000178"/>
+    <j.3:definition>A historical GIS project to create and freely disseminate a database incorporating all available aggregate census information for the United States between 1790 and 2010.</j.3:definition>
+    <j.3:altLabel>NHGIS</j.3:altLabel>
+    <rdfs:comment>**Unsure how to classify this**</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-05T20:19:55Z</dc:date>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:label xml:lang="en">National Historic Geographic Information System</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000290">
+    <rdfs:label xml:lang="en">Stephanie M. Carlson</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:54:16Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000059"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000360"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000060">
+    <j.3:altLabel>Ocean climate working group</j.3:altLabel>
+    <rdfs:label xml:lang="en">Changing ocean working group</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:47:23Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000054"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000072">
+    <owl:sameAs>https://orcid.org/0000-0002-4643-5718</owl:sameAs>
+    <rdfs:label xml:lang="en">Frank Davis</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T19:55:01Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000122"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000100"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000084">
+    <rdfs:label xml:lang="en">James Fall</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:08:46Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000058"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000036"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://schema.org/memberOf">
+    <j.3:definition>An Organization (or ProgramMembership) to which this Person or Organization belongs.</j.3:definition>
+    <rdfs:label>memberOf</rdfs:label>
+    <rdfs:range rdf:nodeID="A49"/>
+    <rdfs:domain rdf:nodeID="A35"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A50">
+    <rdf:rest rdf:nodeID="A51"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000054"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A52">
+    <dc:source>https://en.wikipedia.org/wiki/Tribe_(Native_American)
+https://www.wikidata.org/wiki/Q7840353</dc:source>
+    <owl:annotatedTarget>In the United States, an American Indian tribe, Native American tribe, Alaska Native village, tribal nation, or similar concept is any extant or historical clan, tribe, band, nation, or other group or community of Native Americans in the United States.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000341"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#closeMatch">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A53">
+    <j.2:hasDbXref>https://www.adfg.alaska.gov/index.cfm?adfg=about.mission</j.2:hasDbXref>
+    <owl:annotatedTarget>A department within the government of Alaska which manages approximately 750 active fisheries, 26 game management units, and 32 special areas, with a mission, "To protect, maintain, and improve the fish, game, and aquatic plant resources of the state, and manage their use and development in the best interest of the economy and the well-being of the people of the state, consistent with the sustained yield principle."</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000028"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A54">
+    <dc:source>https://firstalaskans.org/Alaska-Native-Policy-Center/overview/</dc:source>
+    <owl:annotatedTarget>The Alaska Native Policy Center (Policy Center) is a project of the First Alaskans Institute created to support the Native voice and perspective in the public policy-making process. The Policy Center connects people and ideas producing knowledge that can be used to understand and improve the lives of Alaska Natives and all Alaskans. The Policy Center uses a proactive and forward- thinking approach, a focus that is statewide, and a relationship with the Native community that helps Alaska Native leaders and other policy makers access information they can use to help achieve healthy, thriving communities.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000367"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A55">
+    <dc:source>http://www.chistochinaenterprises.com/</dc:source>
+    <owl:annotatedTarget>Chistochina Enterprises is a wholly owned Section 17 Corporation authorized by the 1934 Indian Reorganization Act, formed under a Federal charter to represent the business interests of Cheesh'na and as a means of investing in the future of the Tribe.  Chistochina Enterprises is governed by a five member Board of Director initially appointed by Cheesh'na Tribal Council.  The main office is located in Chistochina, Alaska, and the enterprise is licensed to conduct business in the State of Alaska and nationally as outlined in its Federal charter.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000366"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000180">
+    <j.3:altLabel>SALMoN</j.3:altLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <j.3:definition>A community-based ecological monitoring program initiated by the Stika Conservation Society and the Sitka Sound Science Center, and with close coordination with the USFS Tongass National Forest, and whose purpose is to engage community members in credible ecological monitoring and adaptive management that supports both the health of the environment of Southeast Alaska and the communities living there. This program implements ecological monitoring projects that provide substantive opportunities for community members, especially students, to practice natural resource stewardship, supports management needs, and informs decision-making.</j.3:definition>
+    <rdfs:label xml:lang="en">Southeast Alaska Long-term Monitoring Network</rdfs:label>
+    <dc:description>The SALMoN website is accessible at: http://www.seakecology.org/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-05T20:06:49Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000178"/>
+    <rdfs:comment>**Unsure how to classify this**</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A56">
+    <dc:source>https://en.wikipedia.org/wiki/Arctic_Alaska
+https://www.wikidata.org/wiki/Q3245148</dc:source>
+    <owl:annotatedTarget>Arctic Alaska or Far North Alaska is a region of the U.S. state of Alaska generally referring to the northern areas on or close to the Arctic Ocean.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000003"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000071">
+    <rdfs:label xml:lang="en">hasLeadResearcher</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T19:45:52Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:range rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdfs:domain rdf:nodeID="A57"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000083">
+    <rdfs:label xml:lang="en">Taylor Brelsford</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:08:42Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000058"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000116"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000095">
+    <owl:sameAs>https://orcid.org/0000-0003-1488-820X</owl:sameAs>
+    <rdfs:label xml:lang="en">Dennis Whigham</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:10:04Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000108"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000318">
+    <rdfs:label xml:lang="en">Greg Ruggerone</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:32:58Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000372"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000306">
+    <rdfs:label xml:lang="en">Ginny Litchfield</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:19:46Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000028"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A58">
+    <owl:unionOf rdf:nodeID="A8"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#definition">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A59">
+    <dc:source>http://www.mstc.org/</dc:source>
+    <owl:annotatedTarget>Mt. Sanford Tribal Consortium (Kelt’aeni) is a tribal consortium of two federally recognized Tribal Councils of Chistochina and Mentasta Lake. The consortium was established on June 26, 1992 under a joint effort by Chistochina Village and Mentasta Village to advance and protect common interests of the descendants of the Upper Ahtna indigenous people.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000365"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000090">
+    <rdfs:label xml:lang="en">Michael L. Jones</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:09:31Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000109"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A60">
+    <j.2:hasDbXref>https://mtalab.adfg.alaska.gov/</j.2:hasDbXref>
+    <owl:annotatedTarget>A department within the government of Alaska, which aims to provide fisheries managers and researchers with timely, current, and historical biological data to help them manage, preserve, protect, and perpetuate Alaska's fishery resources. The MTA lab refines and develops diverse methods and means for providing critical data, develops new applications to address management issues and fosters a broad information exchange.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000037"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000329">
+    <rdfs:label xml:lang="en">Andrea Akalleq Sanders</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T17:06:17Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000367"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000317">
+    <rdfs:label xml:lang="en">Ed Farley</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:30:47Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000373"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000305">
+    <rdfs:label xml:lang="en">Steve Baird</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:18:46Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000028"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A61">
+    <owl:unionOf rdf:nodeID="A19"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A62">
+    <dc:source>http://orcid.org/0000-0002-5300-3075</dc:source>
+    <owl:annotatedTarget>A collection of datasets.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000101"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A63">
+    <dc:source>https://schema.org/affiliation</dc:source>
+    <owl:annotatedTarget>An organization that this person is affiliated with. For example, a school/university, a club, or a team.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000066"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/license">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A20">
+    <rdf:rest rdf:nodeID="A64"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000025"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A65">
+    <dc:source>https://inletkeeper.org/about/</dc:source>
+    <owl:annotatedTarget>A community-based nonprofit organization that combines advocacy, education and science toward its mission to protect Alaska’s Cook Inlet watershed and the life it sustains. Inletkeeper’s monitoring and science work builds credibility with scientists and resource managers, its education and advocacy efforts enhance stewardship and citizen participation, and together, these efforts translate into Inletkeeper’s ability to effectively ensure a vibrant and healthy Cook Inlet watershed.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000042"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000308">
+    <rdfs:label xml:lang="en">Karyn DeCino</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:21:17Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000378"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://schema.org/EducationalOccupationalProgram">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000080">
+    <rdfs:label xml:lang="en">Jessica Black</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:08:20Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000056"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000112"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#exactMatch">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000092">
+    <rdfs:label xml:lang="en">Ryan King</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:09:43Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000105"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000319">
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:33:31Z</dc:date>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000371"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:label xml:lang="en">Brendan Connors</rdfs:label>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000345"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000307">
+    <rdfs:label xml:lang="en">Brian Blossom</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:20:28Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000028"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A66">
+    <j.2:hasDbXref>https://en.wikipedia.org/wiki/Investment_company
+https://www.wikidata.org/wiki/Q1752459</j.2:hasDbXref>
+    <owl:annotatedTarget>A financial institution principally engaged in investing in securites (i.e. a tradable financial asset).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000179"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A67">
+    <j.2:hasDbXref>https://dps.alaska.gov/AWT/Home</j.2:hasDbXref>
+    <owl:annotatedTarget>A division wihtin Alaska's Department of Public Safety with a mission to  protect Alaska's Natural Resources through the enfrocement wildlife statutes and regulations.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000040"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A68">
+    <rdfs:comment>This URI does not appear to dereference to the term. Including this URL, https://bioportal.bioontology.org/ontologies/NCIT?p=classes&amp;conceptid=http%3A%2F%2Fncicb.nci.nih.gov%2Fxml%2Fowl%2FEVS%2FThesaurus.owl%23C54073, to ensure findability.</rdfs:comment>
+    <owl:annotatedTarget rdf:resource="http://purl.dataone.org/odo/SASAP_00000026"/>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+    <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C54073"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A69">
+    <owl:unionOf rdf:nodeID="A50"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A70">
+    <j.2:hasDbXref>https://en.wikipedia.org/wiki/Government_agency
+https://www.wikidata.org/wiki/Q327333</j.2:hasDbXref>
+    <owl:annotatedTarget>A permanent or semi-permanent federal govenrment organization which is responsible for the oversight and administration of specific functions.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000025"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A64">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000174"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000091">
+    <rdfs:label xml:lang="en">Coowe Walker</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T20:09:38Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000104"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A71">
+    <dc:source>https://knb.ecoinformatics.org/portals/SASAP/Regions#cookinlet
+https://knb.ecoinformatics.org/view/doi%3A10.5063%2FF1WH2N8W</dc:source>
+    <owl:annotatedTarget>Home to over 60% of Alaska’s residents, the Cook Inlet region may provide a glimpse of the future. Issues of urbanization, road building, and the rise of invasive species are increasingly prominent here. These changes are set within a context of a changing climate and increased conflict among user groups for limited salmon resources.
+
+The bounding coordinates for this SASAP region are:
+North: 63.638 degrees
+South: 58.6157 degrees
+East: -146.1503 degrees
+West: -154.7415 degrees</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000006"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A72">
+    <dc:source>http://www.ccthita.org/</dc:source>
+    <owl:annotatedTarget>The Central Council of the Tlingit and Haida Indian Tribes of Alaska (Tlingit &amp; Haida) is a tribal government representing over 32,000 Tlingit and Haida Indians worldwide. The are a sovereign entity and have a government to government relationship with the United States.
+
+Tlingit &amp; Haida's headquarters are in Juneau, Alaska but their commitment to serving the Tlingit and Haida people extends throughout the United States.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000343"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A57">
+    <owl:unionOf rdf:nodeID="A73"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000338">
+    <j.3:altLabel>The NMFS website is accessible at: https://www.fisheries.noaa.gov/</j.3:altLabel>
+    <j.3:altLabel>NMFS
+NOAA Fisheries</j.3:altLabel>
+    <rdfs:label xml:lang="en">National Marine Fisheries Service</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T17:24:33Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000351"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000025"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000326">
+    <rdfs:label xml:lang="en">Ann Fienup Riordon</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T17:03:34Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000368"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000108">
+    <j.3:exactMatch>https://ror.org/032a13752</j.3:exactMatch>
+    <rdfs:label xml:lang="en">Smithsonian Environmental Research Center</rdfs:label>
+    <rdfs:comment>**Unsure how to classify this**</rdfs:comment>
+    <dc:description>The Smithsonian Environmental Research Center website is accessible at: https://serc.si.edu/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-29T22:59:15Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000390"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000178"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.geneontology.org/formats/oboInOwl#default-namespace">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C54073">
+    <owl:equivalentClass rdf:resource="http://purl.dataone.org/odo/SASAP_00000026"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A74">
+    <dc:source>https://www.oldharbornativecorp.com/</dc:source>
+    <owl:annotatedTarget>Old Harbor Native Corporation (OHNC) was established in 1971 under the terms of the Alaska Native Claims Settlement Act (ANCSA).
+
+OHNC’s mission is to preserve and protect the culture, values and traditions of its community, shareholders and descendants; and to work together to create economic and educational opportunities while promoting self-determination and pride.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000362"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000325">
+    <rdfs:label xml:lang="en">Christian Zimmerman</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:41:34Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000046"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000313">
+    <rdfs:label xml:lang="en">Mandy Bernard</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:26:12Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000375"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000301">
+    <rdfs:label xml:lang="en">Rich Brenner</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:13:20Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000059"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000030"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000410">
+    <rdfs:label xml:lang="en">containsDataFrom</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-22T03:47:36Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:range rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <rdfs:domain rdf:resource="http://purl.dataone.org/odo/SASAP_00000101"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A75">
+    <dc:source>https://knb.ecoinformatics.org/portals/SASAP/Regions#nortonsound
+https://knb.ecoinformatics.org/view/doi%3A10.5063%2FF1WH2N8W</dc:source>
+    <owl:annotatedTarget>An average of two million pink salmon and 250,000 chum salmon return to the sub-Arctic region of Norton Sound, an area approximately twice the size of Massachusetts.
+
+The bounding coordinates of this SASAP region are:
+North: 65.8544 degrees
+South: 62.8268 degrees
+East: -159.1906 degrees
+West: -171.9762 degrees</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000012"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000349">
+    <rdfs:label xml:lang="en">Bechtol Research</rdfs:label>
+    <rdfs:comment>Some information about Bechtol Research may be found at: https://www.alaskabids.us/alaska-contractors/contractor-5277895-BECHTOL-RESEARCH.htm</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T20:04:29Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000183"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000337">
+    <j.3:altLabel>IRES</j.3:altLabel>
+    <rdfs:label>The IRES webpage is accessible at: http://ires.ubc.ca/about-ires/</rdfs:label>
+    <rdfs:label xml:lang="en">Institute for Resources, Environment and Sustainability</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T17:21:43Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000383"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000207"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A76">
+    <dc:source>https://earthlab.uw.edu/2018/09/center-for-creative-conservation-transitions-to-earthlab/</dc:source>
+    <owl:annotatedTarget>Since its establishment, the Center has been a member of UW EarthLab—a new environmental institute housing other groups such as the Climate Impacts Group, the Center for Health and the Global Environment, and the Washington Ocean Acidification Center. EarthLab’s inaugural Executive Director, Ben Packard, has been working over the past year to clarify the vision, priorities and strategic outcomes for EarthLab. As this vision has taken shape, it has become clear that the activities of the Center are a key element of EarthLab. Rather than duplicating the efforts of C3 at the EarthLab level, we have decided to integrate the Center for Creative Conservation into EarthLab.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000396"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000107">
+    <rdfs:label xml:lang="en">School of Aquatic and Fishery Sciences</rdfs:label>
+    <dc:description>The UW School of Aquatic and Fishery Science webpage is accessible at: https://fish.uw.edu/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-29T22:58:06Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000348"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000207"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A38">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000389"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A77">
+    <j.2:hasDbXref>https://www.usgs.gov/about/about-us</j.2:hasDbXref>
+    <owl:annotatedTarget>A bureau of the United Sates Departement of the Interior, which provides science about the natural hazards that threaten lives and livelihoods, the water, energy, minerals, and other natural resources we rely on, the health of our ecosystems and environment, and the impacts of climate and land-use change.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000046"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A78">
+    <dc:source>https://knb.ecoinformatics.org/portals/SASAP/Regions#kuskokwim
+https://knb.ecoinformatics.org/view/doi%3A10.5063%2FF1WH2N8W</dc:source>
+    <owl:annotatedTarget>The Kuskokwim region is the 4th largest of Alaska, and at 154,168 km² is comparable in size to the state of Georgia. The region drains the Kuskokwim – one of the great rivers of the world. The salmon-producing habitat of the Kuskokwim region is diverse and productive. Drier than the neighboring Bristol Bay region, the Kuskokwim region has a larger amount of burn area from forest fires than all other regions but the Yukon.
+
+The bounding coordinates for this SASAP region are:
+North: 64.4166 degrees
+South: 58.6262 degrees
+East: -151.5105 degrees
+West: -173.2164 degrees</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000010"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A79">
+    <dc:source>https://knb.ecoinformatics.org/portals/SASAP/Regions#kodiak
+https://knb.ecoinformatics.org/view/doi%3A10.5063%2FF1WH2N8W</dc:source>
+    <owl:annotatedTarget>The abundance of salmon returning to the largest island in Alaska remain high, though sociocultural challenges loom as large as the 925 glaciers that cling to the island’s coastal and interior mountains.
+
+The bounding coordinates for this SASAP region are:
+North: 59.0261 degrees
+South: 56.3492 degrees
+East: -151.6884 degrees
+West: -156.7838 degrees</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000008"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000336">
+    <owl:sameAs>https://ror.org/01j7nq853</owl:sameAs>
+    <rdfs:label xml:lang="en">University of Alaska Fairbanks</rdfs:label>
+    <rdfs:label>UAF</rdfs:label>
+    <dc:description>The University of Alaska Fairbanks website is accessible at: https://www.uaf.edu/uaf/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T17:17:00Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000393"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A80">
+    <owl:unionOf rdf:nodeID="A81"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A27">
+    <rdf:rest rdf:nodeID="A82"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000025"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000324">
+    <rdfs:label xml:lang="en">Trent Sutton</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:40:42Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000336"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000312">
+    <rdfs:label xml:lang="en">Michael Opheim</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:25:39Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000376"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000300">
+    <owl:sameAs>https://orcid.org/0000-0001-7112-8069</owl:sameAs>
+    <rdfs:label xml:lang="en">Vadim Karatayev</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:12:35Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000354"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A83">
+    <dc:source>http://vivoweb.org/ontology/core#AcademicDepartment</dc:source>
+    <owl:annotatedTarget>A distinct, usually specialized educational unit within an educational organization.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000207"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A84">
+    <dc:source>https://knb.ecoinformatics.org/portals/SASAP/Regions#alaskapeninsulaandaleutianislands
+https://knb.ecoinformatics.org/view/doi%3A10.5063%2FF1WH2N8W</dc:source>
+    <owl:annotatedTarget>Although relatively small in landmass (4th smallest region) the total expanse of the Alaska Peninsula and Aleutian Island region is enormous, spanning over 1600 km (1000 miles) and 10 degrees of longitude.
+
+The bounding coordinates for this SASAP region are:
+North: 57.2997 degrees
+South: 51.1568 degrees
+East: -153.6282 degrees
+West: 179.8567 degrees</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000002"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000328">
+    <rdfs:label xml:lang="en">Melissa Poe</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T17:05:18Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000353"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000351"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2002/07/owl#sameAs">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000207">
+    <j.3:exactMatch rdf:resource="http://vivoweb.org/ontology/core#AcademicDepartment"/>
+    <j.3:definition>A distinct, usually specialized educational unit within an educational organization.</j.3:definition>
+    <rdfs:label xml:lang="en">Academic department</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-12T23:49:48Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <owl:equivalentClass rdf:resource="http://vivoweb.org/ontology/core#AcademicDepartment"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000316">
+    <rdfs:label xml:lang="en">Andrew Gray</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:30:06Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000373"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000304">
+    <rdfs:label xml:lang="en">Chris Guo</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:17:58Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000104"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
+    <j.2:default-namespace>SASAP</j.2:default-namespace>
+    <owl:versionInfo>0.1.1</owl:versionInfo>
+    <rdfs:label>The State of Alaska's Salmon and People Ontology</rdfs:label>
+    <owl:versionIRI rdf:resource="http://purl.dataone.org/odo/SASAP/0.1.1"/>
+    <j.0:creator>https://orcid.org/0000-0002-5300-3075
+https://orcid.org/0000-0002-0381-3766
+https://orcid.org/0000-0003-0632-7576
+https://orcid.org/0000-0003-0077-4738</j.0:creator>
+    <j.0:license>https://creativecommons.org/publicdomain/zero/1.0/</j.0:license>
+    <j.4:GitRepository>https://github.com/DataONEorg/sem-prov-ontologies</j.4:GitRepository>
+    <j.4:bug-database>https://github.com/DataONEorg/sem-prov-ontologies/issues</j.4:bug-database>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTimeStamp">2021-04-19T12:45:10-07:00</dc:date>
+    <dc:description>An ontology which represents information about the State of Alaska's Salmon and People (SASAP) project, as well as knowledge about salmon, features of their habitats, salmon stakeholders, and related entities.</dc:description>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A85">
+    <j.2:hasDbXref>https://www.commerce.alaska.gov/web/</j.2:hasDbXref>
+    <owl:annotatedTarget>A department within the government of Alaska whose mission is to "Promote a healthy economy, strong communities, and protect consumers in Alaska."</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000027"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A86">
+    <j.2:hasDbXref>https://npafc.org/</j.2:hasDbXref>
+    <owl:annotatedTarget>An international inter-governmental organization established by the Convention for the Conservation of Anadromous Stocks in the North Pacific Ocean whose primary objective is to promote the conservation of anadromous stocks in the Convention Area. The Convention Area is the international waters of the North Pacific Ocean and its adjacent seas north of 33° North beyond the 200-mile zones (exclusive economic zones) of the coastal States.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000049"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A87">
+    <rdf:rest rdf:nodeID="A24"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000025"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000303">
+    <rdfs:label xml:lang="en">Syverine Bentz</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:17:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000104"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000339">
+    <rdfs:label xml:lang="en">Kawerak, Inc.</rdfs:label>
+    <dc:description>Kawerak Inc.'s website is accessible at: https://kawerak.org/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T17:45:08Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000097"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000327">
+    <owl:sameAs>https://orcid.org/0000-0001-8842-4884</owl:sameAs>
+    <rdfs:label xml:lang="en">Sara Jo Breslow</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T17:04:16Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000396"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000315">
+    <rdfs:label xml:lang="en">Jacob Argueta</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:27:25Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000104"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A88">
+    <dc:source>http://en.wikipedia.org/wiki/Prince_William_Sound
+https://www.wikidata.org/wiki/Q631282</dc:source>
+    <owl:annotatedTarget>A sound of the Gulf of Alaska on the south coast of the State of Alaska. It is located on the east side of the Kenai Peninsula.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000011"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000109">
+    <j.3:altLabel>Quatitative Fisheries Center</j.3:altLabel>
+    <rdfs:label xml:lang="en">Department of Fisheries and Wildlife Quantitative Fisheries Center</rdfs:label>
+    <dc:description>The Department of Fisheries and Wildlife Quantitative Fisheries Center webpage is accessible at: https://www.canr.msu.edu/qfc/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-29T22:59:25Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000382"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000207"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000314">
+    <rdfs:label xml:lang="en">Alice Rademacher</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:26:39Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000104"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000302">
+    <rdfs:label xml:lang="en">Gale Vick</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:14:25Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000059"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000388"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A49">
+    <owl:unionOf rdf:nodeID="A26"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A89">
+    <dc:source>https://knb.ecoinformatics.org/portals/SASAP/Regions#princewilliamsound
+https://knb.ecoinformatics.org/view/doi%3A10.5063%2FF1WH2N8W</dc:source>
+    <owl:annotatedTarget>Prince William Sound is a region of rain, icefields, and glaciers. Only two (Whittier and Valdez) of Prince William Sound’s largest human communities are connected via road. The terminus of the Alaska oil pipeline ends in this region and results in a fairly high footprint of human activity in a relatively small region. Pink salmon, chum salmon, and sockeye salmon fisheries are current mainstays of local communities with hatchery enhancement of these species (particularly pink salmon) a fundamental dynamic in the region.
+
+The bounding coordinates of this SASAP region are:
+North: 61.5189  degrees
+South: 59.357  degrees
+East: -145.1013  degrees
+West: -149.1761  degrees</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000011"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2002/07/owl#equivalentClass">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A90">
+    <dc:source>https://www.adfg.alaska.gov/index.cfm?adfg=fishingcommercialbyarea.southcentral</dc:source>
+    <owl:annotatedTarget>Central Region Alaska commercial fisheries are composed of four distinct management areas that include Bristol Bay, Prince William Sound and Copper River, Upper Cook Inlet, and Lower Cook Inlet. Although all 5 species of salmon are harvested in each area, sockeye and pink salmon are the most abundant and most valuable. This area encompasses some of the largest and most valuable salmon fisheries in the world. From Bristol Bay, home of the largest sockeye salmon fishery in the world, to the Copper River where sockeye and Chinook salmon fetch some of the highest prices per pound paid to commercial fishermen. Cook Inlet commercial fisheries occur near the largest population center in Alaska, providing salmon to numerous niche and local markets, as well as fresh salmon to markets in other states. Prince William Sound adds productive healthy pink, chum, and sockeye salmon fisheries to the region. Southcentral groundfish fisheries are small, yet diverse, targeting pollock, Pacific cod, rockfish, sablefish, lingcod, and skate while small shrimp and scallop fisheries in Prince William Sound cater predominately to local markets. Southcentral commercial fisheries are of tremendous importance and an integral part of many communities and local economies in the state.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000032"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000007">
+    <j.3:definition>A river in south-central Alaska in the United States. It drains a large region of the Wrangell Mountains and Chugach Mountains into the Gulf of Alaska. The Copper River rises out of the Copper Glacier, which lies on the northeast side of Mount Wrangell, in the Wrangell Mountains, within Wrangell-Saint Elias National Park. It begins by flowing almost due north in a valley that lies on the east side of Mount Sanford, and then turns west, forming the northwest edge of the Wrangell Mountains and separating them from the Mentasta Mountains to the northeast. It continues to turn southeast, through a wide marshy plain to Chitina, where it is joined from the southeast by the Chitina River. Downstream from its confluence with the Chitina it flows southwest, passing through a narrow glacier-lined gap in the Chugach Mountains east of Cordova Peak. There is an extensive area of sand dunes between the Copper and Bremner Rivers. Both Miles Glacier and Child's Glacier calve directly into the river.</j.3:definition>
+    <j.3:closeMatch>http://purl.obolibrary.org/obo/GAZ_00197403</j.3:closeMatch>
+    <rdfs:label xml:lang="en">Copper River</rdfs:label>
+    <dc:description>Fewer than 2500 people live permanently in the Copper River region, an area comparable in size to the state of West Virginia. Sockeye salmon are dominant here, given the multiple large lakes available for rearing juvenile salmon. Though less abundant than sockeye, king salmon are deeply important to all salmon-connected people. Kings have declined in number since 2007.
+
+The bounding coordinates for this SASAP region are:
+North: 63.3227 degrees
+South: 59.7112 degrees
+East: -139.6942 degrees
+West: -147.8251 degrees</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-24T21:28:12Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000001"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A91">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000121"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000103">
+    <rdfs:label xml:lang="en">Data Task Force</rdfs:label>
+    <dc:description>An essential component of the SASAP working group process is the support each group received from a stellar group of “data wranglers”, a team of geospatial analysis experts from NCEAS known as the Data Task Force.
+
+The Task Force coordinated hundreds of data requests from Alaska Department of Fish and Game and other agencies and organizations, then worked to reformat, integrate, and run quality control on millions of lines of data in over 125 data sets.
+
+The graphs, figures, and infograms generated by the Task Force greatly enhanced the ability of users to visualize often complex information about Alaska salmon.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-29T18:12:03Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000054"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000115">
+    <rdfs:label xml:lang="en">Department of Anthropology</rdfs:label>
+    <dc:description>The UAA Department of Anthropology webpage is accessible at: https://www.uaa.alaska.edu/academics/college-of-arts-and-sciences/departments/anthropology/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-29T23:00:42Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000116"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000207"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000006">
+    <j.3:definition>A large estuary stretching 180 miles from the Gulf of Alaska to Anchorage in south-central Alaska. It separates the Kenai Peninsula from mainland Alaska and branches into the Knik Arm and Turnagain Arm at its northern end, almost surrounding Anchorage. The watershed covers about 100,000 km2 of southern Alaska, east of the Aleutian Range and south of the Alaska Range, receiving water from its tributaries the Knik River, the Little Susitna River, and the Susitna and Matanuska rivers. The watershed includes the drainage areas of Mount McKinley. Within the watershed there are several national parks and four historically active volcanoes.</j.3:definition>
+    <j.3:closeMatch>http://purl.obolibrary.org/obo/GAZ_00051076</j.3:closeMatch>
+    <rdfs:label xml:lang="en">Cook Inlet</rdfs:label>
+    <dc:description>Home to over 60% of Alaska’s residents, the Cook Inlet region may provide a glimpse of the future. Issues of urbanization, road building, and the rise of invasive species are increasingly prominent here. These changes are set within a context of a changing climate and increased conflict among user groups for limited salmon resources.
+
+The bounding coordinates for this SASAP region are:
+North: 63.638 degrees
+South: 58.6157 degrees
+East: -146.1503 degrees
+West: -154.7415 degrees</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-24T21:28:08Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000001"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000369">
+    <j.3:definition>The North Slope Borough is the northernmost borough in the US state of Alaska.</j.3:definition>
+    <rdfs:label xml:lang="en">North Slope Borough</rdfs:label>
+    <dc:description>The North Slope Borough's website is accessible at: https://www.north-slope.org/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T22:56:53Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000357">
+    <rdfs:label xml:lang="en">Kuskokwim River Salmon Management Working Group</rdfs:label>
+    <rdfs:comment>**Unsure how to classify this**</rdfs:comment>
+    <dc:description>The Kuskokwim River Salmon Management Working Group (KRSMWG) was formed in 1988 by the Alaska Board of Fisheries (BOF) in response to requests from stakeholders in the Kuskokwim Area who sought a more active role in the management of salmon fishery resources.
+
+The Working Group is made up of 14 member seats representing elders, subsistence fishermen, processors, commercial fishermen, sport fishermen, Kuskokwim River Inter-Tribal Fish Commission, member at large, federal subsistence regional advisory committees, and the Alaska Department of Fish and Game. Non-agency members participate on a voluntary basis and receive no compensation. Participation in the Working Group process requires a great deal of time from its members and agency staff.
+
+The relationship among Working Group members, research planners, project leaders, and policy makers is fostered, and these interactions are critical to the aim of the Working Group. This relationship ensures that participants remain up-to-date on new information and maintain their direct involvement in management of Kuskokwim River salmon fisheries.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T21:05:05Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000345">
+    <rdfs:label xml:lang="en">ESSA Technologies, Ltd.</rdfs:label>
+    <dc:description>ESSA Technologies website is accessible at: https://essa.com/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T19:34:57Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000183"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A92">
+    <j.2:hasDbXref>https://www.legfin.akleg.gov/AgencyInfo/AboutLFD.php</j.2:hasDbXref>
+    <owl:annotatedTarget>A department within the government of Alaska which provides non-partisan budgetary and fiscal analysis to the Alaska Legislature.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000041"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A73">
+    <rdf:rest rdf:nodeID="A91"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000054"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000333">
+    <rdfs:label xml:lang="en">Freddie Christiansen</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T17:09:25Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000362"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000321">
+    <rdfs:label xml:lang="en">Karen Dunmall</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:35:58Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000371"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A93">
+    <dc:source>https://en.wikipedia.org/wiki/Kenai_Peninsula_Borough,_Alaska
+https://www.wikidata.org/wiki/Q512713</dc:source>
+    <owl:annotatedTarget>Kenai Peninsula Borough (Russian: Кенай боро, Kenay boro) is a borough of the U.S. state of Alaska.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000378"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A94">
+    <rdfs:comment>Populates the SASAP Data Portal (https://knb.ecoinformatics.org/portals/SASAP/Data) faceted search field, 'Working Group'</rdfs:comment>
+    <owl:annotatedTarget>Working Group</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000054"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A95">
+    <j.2:hasDbXref>https://alaskasalmonandpeople.org/working-group/social-and-cultural-dimensions-of-salmon-systems/</j.2:hasDbXref>
+    <owl:annotatedTarget>The topics explored by the Sociocultural working group are (1) social and cultural values and relationships between people and salmon, (2) trends in human populations and communities and uses of salmon, and (3) key threads to salmon-dependent communities</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000056"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A96">
+    <j.2:hasDbXref>https://en.wikipedia.org/wiki/Government_agency
+https://www.wikidata.org/wiki/Q327333</j.2:hasDbXref>
+    <owl:annotatedTarget>A permanent or semi-permanent state govenrment organization which is responsible for the oversight and administration of specific functions.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A97">
+    <dc:source>https://www.adfg.alaska.gov/index.cfm?adfg=commercialbyareasoutheast.main</dc:source>
+    <owl:annotatedTarget>The Southeast Alaska/Yakutat Region (Region I) consists of Alaska waters between Cape Suckling on the north and Dixon Entrance on the south. Salmon are commercially harvested in Southeast Alaska with purse seines and drift gillnets; in Yakutat with set gillnets; and in both areas with hand and power troll gear. Herring are harvested in winter bait, sac roe, spawn-on-kelp, and bait pound fisheries. Miscellaneous shellfish (sea cucumber, sea urchins, and geoduck clams) are harvested in dive fisheries in the region. The Alaska Department of Fish and Game (ADF&amp;G) has management jurisdiction over all groundfish resources within state waters in Region I. In addition, the State has management authority for Demersal Shelf Rockfish, ling cod, and black and blue rock fish in both state and federal waters. There are several commercially important shellfish species in Southeast Alaska. They include golden and red king crab, Dungeness crab, Tanner crab, and pandalid shrimp.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000033"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000102">
+    <j.3:definition>A collection of datasets and their metadata which were curated in support of the State of Alaska's Salmon and People (SASAP) Project and accessible at the URL, https://knb.ecoinformatics.org/portals/SASAP/Data</j.3:definition>
+    <j.3:altLabel>SASAP Data Portal</j.3:altLabel>
+    <rdfs:label xml:lang="en">State of Alaska's Salmon and People Data Portal</rdfs:label>
+    <dc:description>The State of Alaska's Salmon and People (SASAP) project is a collaboration of researchers, cultural leaders, and others working to bring together integrated, accurate, and up-to-date information that will help to support better salmon decision-making.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-29T17:34:06Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000101"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000114">
+    <j.3:altLabel>EEB
+UCSC EEB</j.3:altLabel>
+    <rdfs:label xml:lang="en">Department of Ecology and Evolutionary Biology</rdfs:label>
+    <dc:description>The UCSC Department of Ecology and Evolutionary Biology webpage is accessible at: https://www.eeb.ucsc.edu/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-29T23:00:02Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000380"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000207"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000005">
+    <j.3:relatedMatch>http://purl.obolibrary.org/obo/GAZ_00197745
+http://purl.obolibrary.org/obo/GAZ_00197347
+http://purl.obolibrary.org/obo/GAZ_00262790</j.3:relatedMatch>
+    <rdfs:label xml:lang="en">Chignik</rdfs:label>
+    <dc:description>Despite being the smallest salmon-people region of Alaska (6,587 km²), Chignik is remarkably rich in habitat diversity–which translates into biological diversity of its salmon. The Chignik region is home to multiple dispersed communities such as Chignik Lake, Chignik Lagoon, Chignik Bay, Perryville, and Ivanof Bay.
+
+The bounding coordinates for this SASAP region are:
+North: 57.142 degrees
+South: 55.5261 degrees
+East: -155.4645 degrees
+West: -159.6479 degrees</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-24T21:27:57Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000001"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000259">
+    <rdfs:label xml:lang="en">Danielle Ringer</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-19T23:48:38Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000056"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000336"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A81">
+    <rdf:rest rdf:nodeID="A87"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000368">
+    <j.3:altLabel>Calista Education and Culture, Inc.</j.3:altLabel>
+    <rdfs:label xml:lang="en">Calista Elders Council</rdfs:label>
+    <dc:description>The Calista Elders Council was established in 1991 as a non-profit organization representing 1,300 Yup'ik traditional bearers of the Yukon-Kuskokwim Delta in Southwest Alaska. The Calista Elders Council was formed to help protect and preserve the Yup’ik, Cup’ik and Athabascan cultures.
+
+In 2014, after a 20 year history of interacting and working together, the Calista Elders Council, Inc. merged with the former Calista Heritage Foundation to form what is now Calista Education and Culture, Inc.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T22:49:17Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000097"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000356">
+    <j.3:altLabel>Rutgers University
+Rutgers
+RU</j.3:altLabel>
+    <owl:sameAs>https://ror.org/05vt9qd57</owl:sameAs>
+    <rdfs:label xml:lang="en">Rutgers, The State University of New Jersey</rdfs:label>
+    <dc:description>RU's website is accessible at: https://www.rutgers.edu/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T20:32:34Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000393"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000332">
+    <rdfs:label xml:lang="en">Mike Williams</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T17:08:50Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000363"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000358"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000320">
+    <owl:sameAs>https://orcid.org/0000-0002-5314-0109</owl:sameAs>
+    <rdfs:label xml:lang="en">Jim Irvine</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:34:39Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000371"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000348">
+    <j.3:altLabel>UW</j.3:altLabel>
+    <owl:sameAs>https://ror.org/00cvxb145</owl:sameAs>
+    <rdfs:label xml:lang="en">University of Washington</rdfs:label>
+    <dc:description>Learn more about UW at their website: https://www.washington.edu/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T19:46:36Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000393"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000106">
+    <rdfs:label xml:lang="en">School of Geosciences</rdfs:label>
+    <dc:description>The USF School of Geosciences webpage is accessible at: http://hennarot.forest.usf.edu/main/depts/geosci/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-29T22:57:58Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000385"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000207"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000118">
+    <rdfs:label xml:lang="en">Nautilus Impact Investing, LLC</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-29T23:05:25Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000179"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000009">
+    <j.3:relatedMatch>http://purl.obolibrary.org/obo/GAZ_22223765
+http://purl.obolibrary.org/obo/GAZ_00132744
+http://purl.obolibrary.org/obo/GAZ_00198349</j.3:relatedMatch>
+    <rdfs:label xml:lang="en">Kotzebue</rdfs:label>
+    <dc:description>Straddling the Arctic Circle, the Kotzebue region is twice the size of West Virginia and categorized as among the driest areas of Alaska. Chum salmon is the primary species in this region and is harvested by local users in both subsistence and commercial fisheries.
+
+The bounding coordinates for this SASAP region are:
+North: 68.9178 degrees
+South: 65.3082 degrees
+East: 65.3082 degrees
+West: -169.0513 degrees</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-24T21:28:35Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000001"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000105">
+    <owl:sameAs>https://ror.org/005781934</owl:sameAs>
+    <rdfs:label xml:lang="en">Baylor University</rdfs:label>
+    <dc:description>The Baylor University website is accessible at: https://www.baylor.edu/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-29T22:57:21Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000393"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000347">
+    <j.3:altLabel>AYK SSI
+AYK Sustainable Salmon Initiative</j.3:altLabel>
+    <rdfs:label xml:lang="en">Arctic-Yukon-Kuskokwim Sustainable Salmon Initiative</rdfs:label>
+    <dc:description>In response to salmon declines, Bering Sea Fishermen’s Association and regional Native organizations (Association of Village Council Presidents, Kawerak, Inc., and Tanana Chiefs Conference) joined with state and federal agencies to create the AYK SSI, a proactive science-based program working cooperatively to identify and address the critical salmon research needs facing this region. The AYK SSI is the largest example of co-management of research-funding addressing salmon within the Pacific Rim and one of the largest, most successful programs of its kind in North America.
+
+The AYK SSI website is accessible at: https://www.aykssi.org/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T19:43:45Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000178"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A41">
+    <rdf:rest rdf:nodeID="A98"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000054"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000335">
+    <rdfs:label xml:lang="en">Carrie Stevens</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T17:11:42Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000336"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000323">
+    <owl:sameAs>https://orcid.org/0000-0003-4833-2007</owl:sameAs>
+    <rdfs:label xml:lang="en">Todd Sformo</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:39:25Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000369"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000311">
+    <rdfs:label xml:lang="en">Katie McCafferty</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:24:20Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000377"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://schema.org/Project">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A99">
+    <dc:source>https://knb.ecoinformatics.org/portals/SASAP/Regions#chignik
+https://knb.ecoinformatics.org/view/doi%3A10.5063%2FF1WH2N8W</dc:source>
+    <owl:annotatedTarget>Despite being the smallest salmon-people region of Alaska (6,587 km²), Chignik is remarkably rich in habitat diversity–which translates into biological diversity of its salmon. The Chignik region is home to multiple dispersed communities such as Chignik Lake, Chignik Lagoon, Chignik Bay, Perryville, and Ivanof Bay.
+
+The bounding coordinates for this SASAP region are:
+North: 57.142 degrees
+South: 55.5261 degrees
+East: -155.4645 degrees
+West: -159.6479 degrees</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000005"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000359">
+    <j.3:altLabel>DESP</j.3:altLabel>
+    <rdfs:label xml:lang="en">Department of Environmental Science &amp; Policy</rdfs:label>
+    <dc:description>DESP's webpage is accessible at: https://desp.ucdavis.edu/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T21:10:29Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000354"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000207"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000117">
+    <rdfs:label xml:lang="en">Institute of Social and Economic Research</rdfs:label>
+    <dc:description>The UAA Institute of Social and Economic Research webpage is accessible at: https://www.uaa.alaska.edu/research/institute-social-economic-research/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-29T23:01:04Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000116"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000207"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000008">
+    <j.3:definition>A large island on the south coast of the State of Alaska, separated from the Alaska mainland by the Shelikof Strait.</j.3:definition>
+    <j.3:closeMatch>http://purl.obolibrary.org/obo/GAZ_00050020</j.3:closeMatch>
+    <rdfs:label xml:lang="en">Kodiak</rdfs:label>
+    <dc:description>The abundance of salmon returning to the largest island in Alaska remain high, though sociocultural challenges loom as large as the 925 glaciers that cling to the island’s coastal and interior mountains.
+
+The bounding coordinates for this SASAP region are:
+North: 59.0261 degrees
+South: 56.3492 degrees
+East: -151.6884 degrees
+West: -156.7838 degrees</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-24T21:28:29Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000001"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A100">
+    <dc:source>https://alaskasalmonandpeople.org/working-group/biophysical-information-on-salmon-distribution-and-habitat/</dc:source>
+    <owl:annotatedTarget>The goal of the to Biophysical working group is to compare and contrast the status of Alaska salmon and their habitats across regions.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000055"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A101">
+    <dc:source>https://en.wikipedia.org/wiki/National_Historical_Geographic_Information_System</dc:source>
+    <owl:annotatedTarget>A historical GIS project to create and freely disseminate a database incorporating all available aggregate census information for the United States between 1790 and 2010.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000181"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A102">
+    <dc:source>https://alaskasalmonandpeople.org/about/process-people/</dc:source>
+    <owl:annotatedTarget>Beginning in 2016, nine SASAP working groups formed – each composed of between 12 and 24 knowledge experts from a range of disciplines, backgrounds, and regions. Each participant brought his or her data and experiences for synthesis and analysis, while NCEAS provided logistical and technical support to facilitate each group’s innovative work.
+
+Each of the nine groups focused on specific issues related to salmon and people in Alaska:
+
+Four SASAP groups were tasked with integrating knowledge across multiple disciplines to understand the fundamental state of knowledge of Alaska’s salmon systems. The work of each group is presented for each of the major watersheds in Alaska in the Region section (https://alaskasalmonandpeople.org/regions/).
+
+An additional five working groups were selected to focus on specific research questions that provide insight into the pressures on salmon and salmon communities, as well as options for response to those pressures. Their work is presented in the Special Topics section (https://alaskasalmonandpeople.org/topics/).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000054"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A103">
+    <dc:source>http://vivoweb.org/ontology/core#University</dc:source>
+    <owl:annotatedTarget>An institution of higher education and research, which grants academic degrees in a variety of subjects, and provides both undergraduate education and postgraduate education.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000174"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://vivoweb.org/ontology/core#AcademicDepartment">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000104">
+    <j.3:altLabel>KBNERR</j.3:altLabel>
+    <rdfs:label xml:lang="en">Kachemak Bay National Estuarine Research Reserve</rdfs:label>
+    <dc:description>The KBNERR website is accessbile at: https://accs.uaa.alaska.edu/kbnerr/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-29T22:57:11Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000178"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000116">
+    <j.3:altLabel>UAA</j.3:altLabel>
+    <owl:sameAs>https://ror.org/03k3c2t50</owl:sameAs>
+    <rdfs:label xml:lang="en">University of Alaska Anchorage</rdfs:label>
+    <dc:description>The UAA website is accessible at: https://www.uaa.alaska.edu/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-29T23:00:51Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000393"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000358">
+    <j.3:altLabel>KRITFC</j.3:altLabel>
+    <rdfs:label xml:lang="en">Kuskokwim River Inter-Tribal Fish Commission</rdfs:label>
+    <dc:description>KRITFC's website is accessible at: https://www.kuskosalmon.org/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T21:07:27Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000097"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000346">
+    <j.3:altLabel>FAAS</j.3:altLabel>
+    <rdfs:label xml:lang="en">School of Fisheries, Aquaculture &amp; Aquatic Sciences</rdfs:label>
+    <dc:description>The FAAS webpage is accessible at: https://agriculture.auburn.edu/research/faas/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T19:38:05Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000384"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000207"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000334">
+    <rdfs:label xml:lang="en">William Voinot-Baron</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T17:10:53Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000350"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000322">
+    <rdfs:label xml:lang="en">Mike Malick</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:36:53Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000370"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000310">
+    <rdfs:label xml:lang="en">Sue Mauger</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:22:44Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000062"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000042"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A104">
+    <dc:source>https://alaskasalmonandpeople.org/regions/</dc:source>
+    <owl:annotatedTarget>The thirteen SASAP regions were determined based on their geography, and in many cases represent large watersheds where all precipitation melts and flows into the same part of the ocean. Regions tend to also be grouped by Indigenous cultures and languages, evidence of the deep-time ties between Alaska’s salmon and people. Some regions align with current Alaska Department of Fish &amp; Game (ADF&amp;G) statistical areas; some do not.
+
+The bounding coordinates and shapefiles for each region are accessible at: https://knb.ecoinformatics.org/view/doi%3A10.5063%2FF1WH2N8W</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000001"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A98">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000121"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A105">
+    <rdfs:comment>This URI does not appear to dereference to the term. Including this URL, https://bioportal.bioontology.org/ontologies/NCIT?p=classes&amp;conceptid=http%3A%2F%2Fncicb.nci.nih.gov%2Fxml%2Fowl%2FEVS%2FThesaurus.owl%23C54073, to ensure findability.</rdfs:comment>
+    <owl:annotatedTarget rdf:resource="http://purl.dataone.org/odo/SASAP_00000026"/>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+    <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C54073"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A106">
+    <j.2:hasDbXref>http://www.seakecology.org/about-us/</j.2:hasDbXref>
+    <owl:annotatedTarget>A community-based ecological monitoring program initiated by the Stika Conservation Society and the Sitka Sound Science Center, and with close coordination with the USFS Tongass National Forest, and whose purpose is to engage community members in credible ecological monitoring and adaptive management that supports both the health of the environment of Southeast Alaska and the communities living there. This program implements ecological monitoring projects that provide substantive opportunities for community members, especially students, to practice natural resource stewardship, supports management needs, and informs decision-making.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000180"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000111">
+    <rdfs:label xml:lang="en">Coastal Cultures Research</rdfs:label>
+    <rdfs:comment>**Unsure how to classify this**</rdfs:comment>
+    <dc:description>The Coastal Cultures Research website is accessible at: https://www.coastalculturesresearch.com/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-29T22:59:44Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000183"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000002">
+    <j.3:definition>A peninsula extending about 800 km to the southwest from the mainland of Alaska and ending in the Aleutian Islands. The peninsula separates the Pacific Ocean from Bristol Bay, an arm of the Bering Sea.</j.3:definition>
+    <j.3:closeMatch>http://purl.obolibrary.org/obo/GAZ_00055133</j.3:closeMatch>
+    <rdfs:label xml:lang="en">Alaska Peninsula/Aleutian Islands</rdfs:label>
+    <dc:description>Although relatively small in landmass (4th smallest region) the total expanse of the Alaska Peninsula and Aleutian Island region is enormous, spanning over 1600 km (1000 miles) and 10 degrees of longitude.
+
+The bounding coordinates for this SASAP region are:
+North: 57.2997 degrees
+South: 51.1568 degrees
+East: -153.6282 degrees
+West: 179.8567 degrees</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-24T21:27:29Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000001"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A107">
+    <owl:unionOf rdf:nodeID="A5"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A108">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000121"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000014">
+    <j.3:relatedMatch>http://purl.obolibrary.org/obo/GAZ_00069437</j.3:relatedMatch>
+    <rdfs:label xml:lang="en">Yukon</rdfs:label>
+    <dc:description>Larger than the state of Texas and home to the third longest river in the United States, the Yukon region is a governance mosaic of state and federal fisheries management.
+
+The bounding coordinates for this SASAP region are:
+North: 69.0792 degrees
+South: 58.8686 degrees
+East: -129.1775 degrees
+West: -166.281 degrees</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-24T21:29:06Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000001"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000026">
+    <j.3:exactMatch rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C54073"/>
+    <j.3:definition>An organization whose primary objective is to support some issue or matter of private interest or public concern for non-commercial purposes. Nonprofits generally do not operate to generate profit, and this characteristic is popularly considered to be the defining characterisitic of such organizations. However, a non-profit organization may accept, hold and disburse money and other things of value. It may also legally and ethically trade at a profit. The extent to which it can generate income may be constrained, or the use of those profits may be restricted.</j.3:definition>
+    <j.3:altLabel>Nonprofit
+Non-profit
+Nonprofit organization
+NPO
+Nonprofit group
+Non-profit organization
+Not for profit organization</j.3:altLabel>
+    <rdfs:label xml:lang="en">Nonprofit organization</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:01:44Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000038">
+    <j.3:definition>The Alaska Department of Labor and Workforce Development (DOLWD) is a department within the govenrment of Alaska which handles most of the state's labor and workforce issues, primarily at the administrative level.</j.3:definition>
+    <owl:sameAs>https://ror.org/05pc4pd06</owl:sameAs>
+    <rdfs:label xml:lang="en">Alaska Department of Labor and Workforce Development</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:04:28Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000268">
+    <rdfs:label xml:lang="en">Alex Whiting</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T00:00:12Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000056"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000342"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000389">
+    <rdfs:label xml:lang="en">Museum</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T17:30:14Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000256">
+    <rdfs:label xml:lang="en">hasAdvisor</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-19T23:40:58Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:range rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdfs:domain rdf:nodeID="A69"/>
+    <owl:inverseOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000257"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://schema.org/member">
+    <j.3:definition>A member of an Organization or a ProgramMembership. Organizations can be members of organizations; ProgramMembership is typically for individuals.</j.3:definition>
+    <rdfs:label>member</rdfs:label>
+    <rdfs:range rdf:nodeID="A80"/>
+    <rdfs:domain rdf:nodeID="A61"/>
+    <owl:inverseOf rdf:resource="https://schema.org/memberOf"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000377">
+    <j.3:altLabel>USACE
+US Army Corps of Engineers</j.3:altLabel>
+    <rdfs:label xml:lang="en">United States Army Corps of Engineers</rdfs:label>
+    <dc:description>UCACE's website is accessible at: https://www.usace.army.mil/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T23:28:01Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000025"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000365">
+    <j.3:definition>The Mt. Sanford Tribal Consortium's website is accessible at: http://www.mstc.org/</j.3:definition>
+    <j.3:definition>Mt. Sanford Tribal Consortium (Kelt’aeni) is a tribal consortium of two federally recognized Tribal Councils of Chistochina and Mentasta Lake. The consortium was established on June 26, 1992 under a joint effort by Chistochina Village and Mentasta Village to advance and protect common interests of the descendants of the Upper Ahtna indigenous people.</j.3:definition>
+    <rdfs:label xml:lang="en">Mt. Sanford Tribal Consortium</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T22:26:16Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000097"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000353">
+    <j.3:altLabel>WSG
+Sea Grant Washington</j.3:altLabel>
+    <rdfs:label xml:lang="en">Washington Sea Grant</rdfs:label>
+    <dc:description>WSG's website is accessible at: https://wsg.washington.edu/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T20:14:57Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000348"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000352"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000341">
+    <j.3:definition>In the United States, an American Indian tribe, Native American tribe, Alaska Native village, tribal nation, or similar concept is any extant or historical clan, tribe, band, nation, or other group or community of Native Americans in the United States.</j.3:definition>
+    <j.3:altLabel>American Indian tribe
+Native American tribe
+Alaska Native village
+Native village</j.3:altLabel>
+    <rdfs:label xml:lang="en">Tribal nation</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T17:59:45Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A109">
+    <dc:source>https://knb.ecoinformatics.org/portals/SASAP/Regions#bristolbay
+https://knb.ecoinformatics.org/view/doi%3A10.5063%2FF1WH2N8W</dc:source>
+    <owl:annotatedTarget>Bristol Bay is sockeye salmon country. The region is a land of great inland lakes, ideally suited to the juvenile life of sockeye salmon. The habitats here are virtually pristine and intact with a notable absence of mining and offshore oil and gas exploration in the region. The long proposed Pebble Mine, situated at the intersection between the Nushagak River and Kvichak River watersheds, would unquestionably and permanently change this salmon landscape.
+
+The bounding coordinates for this SASAP region are:
+North: 60.9278 degrees
+South: 56.8716 degrees
+East: -152.7319 degrees
+West: -162.2713 degrees</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000004"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A110">
+    <j.2:hasDbXref>https://mtalab.adfg.alaska.gov/</j.2:hasDbXref>
+    <owl:annotatedTarget>The Mark Lab (https://mtalab.adfg.alaska.gov/OTO/Default.aspx) tracks Alaska's salmon populations by deciphering thermal marks induced in fish otoliths. The Tag Lab (https://mtalab.adfg.alaska.gov/CWT/Default.aspx) is the centralized state resoruce for tracking salmon using microsopic coded wire tags. The Age Determination Lab (https://mtalab.adfg.alaska.gov/ADU/Default.aspx) is a statewide age reading service which produces data for fish and invertebrates sampled during commercial, population survey, and research harvests.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000037"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#relatedMatch">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A111">
+    <j.2:hasDbXref>https://en.wikipedia.org/wiki/United_States_Census_Bureau</j.2:hasDbXref>
+    <owl:annotatedTarget>A principle agency of the U.S. Federal Satistical System, whose responsibility and mission is to serve as the nation's leading provider of quality data about its people and economy.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000044"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A112">
+    <dc:source>http://en.wikipedia.org/wiki/Copper_River_(Alaska)
+https://www.wikidata.org/wiki/Q1131444</dc:source>
+    <owl:annotatedTarget>A river in south-central Alaska in the United States. It drains a large region of the Wrangell Mountains and Chugach Mountains into the Gulf of Alaska. The Copper River rises out of the Copper Glacier, which lies on the northeast side of Mount Wrangell, in the Wrangell Mountains, within Wrangell-Saint Elias National Park. It begins by flowing almost due north in a valley that lies on the east side of Mount Sanford, and then turns west, forming the northwest edge of the Wrangell Mountains and separating them from the Mentasta Mountains to the northeast. It continues to turn southeast, through a wide marshy plain to Chitina, where it is joined from the southeast by the Chitina River. Downstream from its confluence with the Chitina it flows southwest, passing through a narrow glacier-lined gap in the Chugach Mountains east of Cordova Peak. There is an extensive area of sand dunes between the Copper and Bremner Rivers. Both Miles Glacier and Child's Glacier calve directly into the river.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000007"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://usefulinc.com/ns/doap#bug-database">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000110">
+    <j.3:exactMatch>https://ror.org/0551hes90</j.3:exactMatch>
+    <rdfs:label xml:lang="en">Prince William Sound Science Center</rdfs:label>
+    <dc:description>The Prince William Sound Center website is accessible at: https://pwssc.org/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-29T22:59:33Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000026"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000001">
+    <rdfs:label xml:lang="en">SASAP Region</rdfs:label>
+    <rdfs:comment>Populates the SASAP Data Portal (https://knb.ecoinformatics.org/portals/SASAP/Data) faceted search field, 'SASAP Region'</rdfs:comment>
+    <dc:description>The thirteen SASAP regions were determined based on their geography, and in many cases represent large watersheds where all precipitation melts and flows into the same part of the ocean. Regions tend to also be grouped by Indigenous cultures and languages, evidence of the deep-time ties between Alaska’s salmon and people. Some regions align with current Alaska Department of Fish &amp; Game (ADF&amp;G) statistical areas; some do not.
+
+The bounding coordinates and shapefiles for each region are accessible at: https://knb.ecoinformatics.org/view/doi%3A10.5063%2FF1WH2N8W</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-24T21:24:20Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000122">
+    <j.3:definition>A collaborative project which seeks to provide a holistic, statewide overview of the status and characteristics of Alaska's coupled human-salmon system.</j.3:definition>
+    <j.3:altLabel>SASAP
+SASAP Project</j.3:altLabel>
+    <rdfs:label xml:lang="en">The State of Alaska's Salmon and People Project</rdfs:label>
+    <dc:description>The SASAP project is a deep assessment of the state of knowledge of the biological, sociocultural, economic and governance dimensions of Alaska's salmon and the people who depend upon them. The SASAP project shares this knowledge with Alaska salmon users through comprehensive watershed-level summaries (Regions), focused research on specific salmon issues (Topics), and suppported links to SASAP's free, open-source datasets, accessible through the SASAP Data Portal (https://knb.ecoinformatics.org/portals/SASAP/Data).</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-30T20:31:38Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000121"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000013">
+    <j.3:definition>The southeastern portion of the coast of the State of Alaska, which lies just west of the northern half of the Canadian province of British Columbia. The majority of the panhandle's area is part of the Tongass National Forest, the United States's largest national forest. In many places, the international border runs along the crest of the Boundary Ranges of the Coast Mountains.</j.3:definition>
+    <j.3:closeMatch>http://purl.obolibrary.org/obo/GAZ_00055328</j.3:closeMatch>
+    <j.3:altLabel>Southeast Alaska
+Alaska Panhandle
+Alaskan Panhandle</j.3:altLabel>
+    <rdfs:label xml:lang="en">Southeast</rdfs:label>
+    <dc:description>Approximately the size of the state of Kansas, the Southeast region is categorized by thousands of small coastal watersheds that provide ideal spawning habitat for pink salmon and chum salmon in particular. All five species are caught and return to this region. In terms of total abundance of salmon, Southeast Alaska dominates the state. Managing and conserving salmon populations that move beyond international borders is a key challenge here as many of the Chinook salmon caught in Southeast were hatched outside Alaska.
+
+The bounding coordinates for this SASAP region are:
+North: 61.6887 degrees
+South: 54.2508 degrees
+East: -126.7735 degrees
+West: -143.8874 degrees</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-24T21:29:03Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000001"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A82">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000174"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000025">
+    <j.3:relatedMatch>http://purl.bioontology.org/ontology/MESH/D035082</j.3:relatedMatch>
+    <j.3:relatedMatch rdf:resource="http://vivoweb.org/ontology/core#GovernmentAgency"/>
+    <j.3:definition>A permanent or semi-permanent federal govenrment organization which is responsible for the oversight and administration of specific functions.</j.3:definition>
+    <rdfs:label xml:lang="en">Federal government department, division, or agency</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:01:18Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000037">
+    <dc:description>The Mark Lab (https://mtalab.adfg.alaska.gov/OTO/Default.aspx) tracks Alaska's salmon populations by deciphering thermal marks induced in fish otoliths. The Tag Lab (https://mtalab.adfg.alaska.gov/CWT/Default.aspx) is the centralized state resoruce for tracking salmon using microsopic coded wire tags. The Age Determination Lab (https://mtalab.adfg.alaska.gov/ADU/Default.aspx) is a statewide age reading service which produces data for fish and invertebrates sampled during commercial, population survey, and research harvests.</dc:description>
+    <j.3:altLabel>MTA
+MTA Lab</j.3:altLabel>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000028"/>
+    <rdfs:label xml:lang="en">Alaska Department of Fish and Game, Mark, Tag and Age Laboratory</rdfs:label>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <j.3:definition>A department within the government of Alaska, which aims to provide fisheries managers and researchers with timely, current, and historical biological data to help them manage, preserve, protect, and perpetuate Alaska's fishery resources. The MTA lab refines and develops diverse methods and means for providing critical data, develops new applications to address management issues and fosters a broad information exchange.</j.3:definition>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:04:24Z</dc:date>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000049">
+    <j.3:definition>An international inter-governmental organization established by the Convention for the Conservation of Anadromous Stocks in the North Pacific Ocean whose primary objective is to promote the conservation of anadromous stocks in the Convention Area. The Convention Area is the international waters of the North Pacific Ocean and its adjacent seas north of 33° North beyond the 200-mile zones (exclusive economic zones) of the coastal States.</j.3:definition>
+    <j.3:altLabel>NPAFC</j.3:altLabel>
+    <rdfs:label xml:lang="en">North Pacific Anadromous Fish Commission</rdfs:label>
+    <dc:description>The North Pacific Anadrmous Fish Commission's website is accessbile at: https://npafc.org/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:06:17Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000048"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000279">
+    <rdfs:label xml:lang="en">Janessa Esquible</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:46:03Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000050"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000388">
+    <j.3:altLabel>TCC</j.3:altLabel>
+    <rdfs:label xml:lang="en">Tanana Chiefs Conference</rdfs:label>
+    <dc:description>The Tanana Chiefs Conference website is accessible at: https://www.tananachiefs.org/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T17:25:34Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000097"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000267">
+    <rdfs:label xml:lang="en">Ben Stevens</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-19T23:59:58Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000056"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000340"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000376">
+    <j.3:altLabel>SVT's website is accessible at: https://svt.org/</j.3:altLabel>
+    <j.3:altLabel>SVT</j.3:altLabel>
+    <rdfs:label xml:lang="en">Seldovia Village Tribe</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T23:26:20Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000341"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000255">
+    <rdfs:label xml:lang="en">hasSupportingResearcher</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-19T21:20:01Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:range rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdfs:domain rdf:nodeID="A58"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000364">
+    <j.3:altLabel>Georgetown Tribe</j.3:altLabel>
+    <rdfs:label xml:lang="en">Native Village of Georgetown</rdfs:label>
+    <dc:description>Find more information about the Native Village of Georgetown at: https://www.bia.gov/tribal-leaders/georgetown</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T21:34:02Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000341"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000352">
+    <rdfs:label xml:lang="en">Federal/state partnerships and programs</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T20:14:46Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000340">
+    <j.3:altLabel>YRITFC</j.3:altLabel>
+    <rdfs:label xml:lang="en">Yukon River Inter-Tribal Fish Commission</rdfs:label>
+    <j.2:hasDbXref>https://salmonlife.org/yellow/stewardship/one-voice-one-river/</j.2:hasDbXref>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T17:50:28Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000026"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A113">
+    <j.2:hasDbXref>https://labor.alaska.gov/</j.2:hasDbXref>
+    <dc:source>https://en.wikipedia.org/wiki/Alaska_Department_of_Labor_and_Workforce_Development</dc:source>
+    <owl:annotatedTarget>The Alaska Department of Labor and Workforce Development (DOLWD) is a department within the govenrment of Alaska which handles most of the state's labor and workforce issues, primarily at the administrative level.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000038"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A114">
+    <j.2:hasDbXref>http://www.adfg.alaska.gov/index.cfm?adfg=divisions.cfoverview</j.2:hasDbXref>
+    <owl:annotatedTarget>A department within the government of Alaska which manages commercial, subsistence, and personal use fisheries within the jurisdiction of the State of Alaska.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000030"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A115">
+    <j.2:hasDbXref>https://alaskasalmonandpeople.org/working-group/economic-dimensions-of-salmon-systems/</j.2:hasDbXref>
+    <owl:annotatedTarget>The goals of the Economic working group are to (1) identify important trends in the historical relationships between salmon and salmon users which may have been overlooked, (2) inform and support evidence-based policy aimed at sustainable and equitable decision making, and (3) compile, archive, and share relevant historical socioeconomic data about Alaska's salmon systems.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000057"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000029">
+    <j.3:definition>A department within the government of Alaska which helps to conserve and maintain the economic health of Alaska’s commercial fisheries by limiting the number of participating fishers. The Commission issues permits and vessel licenses to qualified individuals in both limited and unlimited fisheries, and provides due process hearings and appeal processes for disputes related to limitations on fishery participation.</j.3:definition>
+    <rdfs:label xml:lang="en">Alaska Department of Fish and Game, Commercial Fisheries Entry Commission</rdfs:label>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000028"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.3:altLabel>CFEC</j.3:altLabel>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:03:30Z</dc:date>
+    <dc:description>The CFEC website is accessible at: https://cfec.state.ak.us/</dc:description>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A116">
+    <dc:source>https://alaskasalmonandpeople.org/</dc:source>
+    <owl:annotatedTarget>A collaborative project which seeks to provide a holistic, statewide overview of the status and characteristics of Alaska's coupled human-salmon system.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000122"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/creator">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000101">
+    <j.3:relatedMatch rdf:resource="https://schema.org/Collection"/>
+    <j.3:definition>A collection of datasets.</j.3:definition>
+    <rdfs:label xml:lang="en">Data corpus</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-29T17:33:25Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000113">
+    <rdfs:label xml:lang="en">College of Fisheries &amp; Ocean Sciences</rdfs:label>
+    <dc:description>The UAF College of Fisheries &amp; Ocean Sciences webpage is accessible at: https://www.uaf.edu/cfos/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-29T22:59:55Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000336"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000207"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000004">
+    <j.3:definition>The eastern-most arm of the Bering Sea. It is located between the southwest part of the Alaska mainland to its north, and the Alaska Peninsula to its south and east. Bristol Bay is 400 km long and 290 km wide at its mouth. A number of rivers flow into the bay, including the Cinder, Igushik, Kvichak, Meshik, Nushagak, Naknek, Togiak, and Ugashik.</j.3:definition>
+    <j.3:closeMatch>http://purl.obolibrary.org/obo/GAZ_00055147</j.3:closeMatch>
+    <rdfs:label xml:lang="en">Bristol Bay</rdfs:label>
+    <dc:description>Bristol Bay is sockeye salmon country. The region is a land of great inland lakes, ideally suited to the juvenile life of sockeye salmon. The habitats here are virtually pristine and intact with a notable absence of mining and offshore oil and gas exploration in the region. The long proposed Pebble Mine, situated at the intersection between the Nushagak River and Kvichak River watersheds, would unquestionably and permanently change this salmon landscape.
+
+The bounding coordinates for this SASAP region are:
+North: 60.9278 degrees
+South: 56.8716 degrees
+East: -152.7319 degrees
+West: -162.2713 degrees</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-24T21:27:48Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000001"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A45">
+    <rdf:rest rdf:nodeID="A108"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000054"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000028">
+    <j.3:definition>A department within the government of Alaska which manages approximately 750 active fisheries, 26 game management units, and 32 special areas, with a mission, "To protect, maintain, and improve the fish, game, and aquatic plant resources of the state, and manage their use and development in the best interest of the economy and the well-being of the people of the state, consistent with the sustained yield principle."</j.3:definition>
+    <owl:sameAs>https://ror.org/02rh7vj17</owl:sameAs>
+    <rdfs:label xml:lang="en">Alaska Department of Fish and Game</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:03:25Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000258">
+    <rdfs:label xml:lang="en">Jesse Coleman</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-19T23:46:33Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000056"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000336"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000379">
+    <rdfs:label xml:lang="en">Alaska Fisheries Science Center</rdfs:label>
+    <dc:description>The Alaska Fisheries Science Center's website is accessible at: https://www.fisheries.noaa.gov/about/alaska-fisheries-science-center</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T16:03:29Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000351"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000367">
+    <j.3:definition>The Alaska Native Policy Center (Policy Center) is a project of the First Alaskans Institute created to support the Native voice and perspective in the public policy-making process. The Policy Center connects people and ideas producing knowledge that can be used to understand and improve the lives of Alaska Natives and all Alaskans. The Policy Center uses a proactive and forward- thinking approach, a focus that is statewide, and a relationship with the Native community that helps Alaska Native leaders and other policy makers access information they can use to help achieve healthy, thriving communities.</j.3:definition>
+    <rdfs:label xml:lang="en">Alaska Native Policy Center</rdfs:label>
+    <dc:description>The Alaska Native Policy Center at the First Alaskans Institute's website is accessible at: https://firstalaskans.org/Alaska-Native-Policy-Center/overview/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T22:31:05Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000097"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000355">
+    <j.3:altLabel>SFU</j.3:altLabel>
+    <owl:sameAs>https://ror.org/0213rcc28</owl:sameAs>
+    <rdfs:label xml:lang="en">Simon Fraser University</rdfs:label>
+    <dc:description>SFU's website is accessible at: https://www.sfu.ca/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T20:29:55Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000394"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000343">
+    <j.3:definition>The Central Council of the Tlingit and Haida Indian Tribes of Alaska (Tlingit &amp; Haida) is a tribal government representing over 32,000 Tlingit and Haida Indians worldwide. The are a sovereign entity and have a government to government relationship with the United States.
+
+Tlingit &amp; Haida's headquarters are in Juneau, Alaska but their commitment to serving the Tlingit and Haida people extends throughout the United States.</j.3:definition>
+    <rdfs:label xml:lang="en">Central Council of the Tlingit &amp; Haida Indian Tribes of Alaska</rdfs:label>
+    <dc:description>The Central Council of the Tlingit and Haida Indian Tribes of Alaska website is accessbile at: http://www.ccthita.org/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T18:49:58Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000341"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000331">
+    <rdfs:label xml:lang="en">Jonathan Samuelson</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T17:07:36Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000364"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000358"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#altLabel">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A117">
+    <dc:source>http://www.adfg.alaska.gov/index.cfm?adfg=commercialbyareakuskokwim.kswg</dc:source>
+    <owl:annotatedTarget>The Kuskokwim River Salmon Management Working Group (KRSMWG) was formed in 1988 by the Alaska Board of Fisheries (BOF) in response to requests from stakeholders in the Kuskokwim Area who sought a more active role in the management of salmon fishery resources.
+
+The Working Group is made up of 14 member seats representing elders, subsistence fishermen, processors, commercial fishermen, sport fishermen, Kuskokwim River Inter-Tribal Fish Commission, member at large, federal subsistence regional advisory committees, and the Alaska Department of Fish and Game. Non-agency members participate on a voluntary basis and receive no compensation. Participation in the Working Group process requires a great deal of time from its members and agency staff.
+
+The relationship among Working Group members, research planners, project leaders, and policy makers is fostered, and these interactions are critical to the aim of the Working Group. This relationship ensures that participants remain up-to-date on new information and maintain their direct involvement in management of Kuskokwim River salmon fisheries.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000357"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A118">
+    <dc:source>http://www.adfg.alaska.gov/index.cfm?adfg=divisions.subsmission</dc:source>
+    <owl:annotatedTarget>The Subsistence Section provides the following core services: (a) Compile and analyze existing data; conduct research to gather information on the role of hunting and fishing by Alaskans for customary and traditional uses, (b) Disseminate current subsistence use information to the public; appropriate agencies and organizations; and fisheries and wildlife management divisions, (c) Assist the Board of Fisheries, the Board of Game, and the Joint Board of Fisheries and Game to evaluate customary and traditional uses of Alaska's fish and wildlife resources and amounts reasonably necessary for subsistence uses (ANS) of those resources, and (d) Assist fisheries and wildlife managers in preparing management plans to ensure information on customary and traditional uses and fish and wildlife harvests is incorporated.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000036"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000100">
+    <j.3:exactMatch>https://ror.org/0146z4r19</j.3:exactMatch>
+    <j.3:definition>A research center of the University of California, Santa Barbara which fosters collaborative synthesis research by assembling interdisciplinary teams to distill existing data, ideas, theories, or methods drawn from many sources, across multiple fields of inquiry, in order to accelerate the generation of new knowledge on a broad scale.</j.3:definition>
+    <j.3:altLabel>National Center for Ecological Analysis &amp; Synthesis
+NCEAS</j.3:altLabel>
+    <rdfs:label xml:lang="en">National Center for Ecological Analysis and Synthesis</rdfs:label>
+    <dc:description>The NCEAS website is accessible at: https://www.nceas.ucsb.edu/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-27T00:18:57Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000178"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A119">
+    <dc:source>https://knb.ecoinformatics.org/portals/SASAP/Regions#southeast
+https://knb.ecoinformatics.org/view/doi%3A10.5063%2FF1WH2N8W</dc:source>
+    <owl:annotatedTarget>Approximately the size of the state of Kansas, the Southeast region is categorized by thousands of small coastal watersheds that provide ideal spawning habitat for pink salmon and chum salmon in particular. All five species are caught and return to this region. In terms of total abundance of salmon, Southeast Alaska dominates the state. Managing and conserving salmon populations that move beyond international borders is a key challenge here as many of the Chinook salmon caught in Southeast were hatched outside Alaska.
+
+The bounding coordinates for this SASAP region are:
+North: 61.6887 degrees
+South: 54.2508 degrees
+East: -126.7735 degrees
+West: -143.8874 degrees</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000013"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000112">
+    <j.3:altLabel>DANSRD</j.3:altLabel>
+    <rdfs:label xml:lang="en">Department of Alaska Native Studies and Rural Development</rdfs:label>
+    <dc:description>The UAF Alaska Native Studies and Rural Development webpage is accessible at: https://www.uaf.edu/dansrd/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-29T22:59:49Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000336"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000207"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000003">
+    <j.3:definition>Arctic Alaska or Far North Alaska is a region of the U.S. state of Alaska generally referring to the northern areas on or close to the Arctic Ocean.</j.3:definition>
+    <j.3:altLabel>Far North Alaska</j.3:altLabel>
+    <rdfs:label xml:lang="en">Arctic</rdfs:label>
+    <dc:description>In the Arctic region of Alaska, connections between salmon and people are in their infancy. Salmon are just one harbinger of change in this region.
+
+The bounding coordinates for this SASAP region are:
+North: 71.4396 degrees
+South: 67.7408 degrees
+East: -136.684 degrees
+West: -166.311 degrees</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-24T21:27:43Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000001"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000027">
+    <j.3:definition>A department within the government of Alaska whose mission is to "Promote a healthy economy, strong communities, and protect consumers in Alaska."</j.3:definition>
+    <owl:sameAs>https://ror.org/0580q1236</owl:sameAs>
+    <rdfs:label xml:lang="en">Alaska Department of Commerce, Community, and Economic Development</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:03:19Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000039">
+    <j.3:definition>A division within the government of Alaska's Department of Natural Resources (DNR) which maintains the department's land records repository and oversees DNR's computer systems and networks services. It provides for the department's data processing functions including development, training, operations, and maintenance. The Department of Natural Resources' (DNR) systems include the Land Administration System (LAS), the Geographic Information System, the Revenue and Billing System, and others. The section also produces and maintains the state's land status maps.</j.3:definition>
+    <j.3:altLabel>Alaska Department of Natural Resources, IRM</j.3:altLabel>
+    <rdfs:label xml:lang="en">Alaska Department of Natural Resources, Support Services Division, Information Resource Management</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:04:32Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000269">
+    <rdfs:label xml:lang="en">Sam Truesdell</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:27:23Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000109"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000257">
+    <rdfs:label xml:lang="en">isAdvisorTo</rdfs:label>
+    <dc:description>In addition to a lead researcher, some SASAP working groups have an additional advisor(s) to assist in the research efforts. The 'isAdvisorTo' object property connects advisors to their respective working groups.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-19T23:41:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:range rdf:nodeID="A107"/>
+    <rdfs:domain rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000378">
+    <j.3:definition>Kenai Peninsula Borough (Russian: Кенай боро, Kenay boro) is a borough of the U.S. state of Alaska.</j.3:definition>
+    <j.3:altLabel>KPB</j.3:altLabel>
+    <rdfs:label xml:lang="en">Kenai Peninsula Borough</rdfs:label>
+    <dc:description>The Kenai Peninsula Borough's website is accessible at: https://www.kpb.us/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T23:33:12Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000366">
+    <j.3:definition>Chistochina Enterprises is a wholly owned Section 17 Corporation authorized by the 1934 Indian Reorganization Act, formed under a Federal charter to represent the business interests of Cheesh'na and as a means of investing in the future of the Tribe.  Chistochina Enterprises is governed by a five member Board of Director initially appointed by Cheesh'na Tribal Council.  The main office is located in Chistochina, Alaska, and the enterprise is licensed to conduct business in the State of Alaska and nationally as outlined in its Federal charter.</j.3:definition>
+    <rdfs:label xml:lang="en">Christochina Enterprises</rdfs:label>
+    <dc:description>Christochina Enterprises' website is accessible at: http://www.chistochinaenterprises.com</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T22:28:28Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000097"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000354">
+    <j.3:altLabel>UC Davis</j.3:altLabel>
+    <owl:sameAs>https://ror.org/05rrcem69</owl:sameAs>
+    <rdfs:label xml:lang="en">University of California, Davis</rdfs:label>
+    <dc:description>UC Davis's website is accessible at: https://www.ucdavis.edu/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T20:18:20Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000393"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000342">
+    <rdfs:label xml:lang="en">Native Village of Kotzebue</rdfs:label>
+    <dc:description>More information about the Native Village of Kotzebue can be found at: https://www.nwabor.org/village/kotzebue/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T18:02:31Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000341"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000330">
+    <rdfs:label xml:lang="en">Wilson Justin</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T17:06:54Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000366"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000365"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A4">
+    <rdf:rest rdf:nodeID="A12"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000025"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A6">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000121"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000010">
+    <j.3:relatedMatch>http://purl.obolibrary.org/obo/GAZ_00147944
+http://purl.obolibrary.org/obo/GAZ_00197646
+http://purl.obolibrary.org/obo/GAZ_00055346</j.3:relatedMatch>
+    <rdfs:label xml:lang="en">Kuskokwim</rdfs:label>
+    <dc:description>The Kuskokwim region is the 4th largest of Alaska, and at 154,168 km² is comparable in size to the state of Georgia. The region drains the Kuskokwim – one of the great rivers of the world. The salmon-producing habitat of the Kuskokwim region is diverse and productive. Drier than the neighboring Bristol Bay region, the Kuskokwim region has a larger amount of burn area from forest fires than all other regions but the Yukon.
+
+The bounding coordinates for this SASAP region are:
+North: 64.4166 degrees
+South: 58.6262 degrees
+East: -151.5105 degrees
+West: -173.2164 degrees</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-24T21:28:48Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000001"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000034">
+    <j.3:definition>A department within the government of Alaska which (a) has the specific statutory responsibility of protecting freshwater habitat for anadromous fish and providing free passage for all fish in freshwater bodies, (b) develops management plans and oversees activities (excluding trapping, hunting, fishing, and wildlife viewing) in legislatively designated refuges, critical habitat areas, and sanctuaries known collectively as Special Areas, (c) works with the Division of Sport Fish to update the “Catalog of Waters Important for the Spawning, Rearing, or Migration of Anadromous Fishes,” (d) coordinates the ADF&amp;G review of large and complex projects important to the State, and (e) works closely with the ADNR Division of Forestry to survey State and private forestry operations and evaluate implementation of Alaska’s Forest Resources and Practices Act (FRPA).</j.3:definition>
+    <rdfs:label xml:lang="en">Alaska Department of Fish and Game, Division of Habitat</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:04:11Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000028"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000046">
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:05:35Z</dc:date>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000025"/>
+    <rdfs:label xml:lang="en">United States Geologic Survey</rdfs:label>
+    <j.3:exactMatch>https://ror.org/035a68863</j.3:exactMatch>
+    <j.3:definition>A bureau of the United Sates Departement of the Interior, which provides science about the natural hazards that threaten lives and livelihoods, the water, energy, minerals, and other natural resources we rely on, the health of our ecosystems and environment, and the impacts of climate and land-use change.</j.3:definition>
+    <dc:description>The USGS website is accessible at: https://www.usgs.gov/</dc:description>
+    <j.3:altLabel>USGS</j.3:altLabel>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000058">
+    <j.3:altLabel>Governance working group</j.3:altLabel>
+    <rdfs:label xml:lang="en">Governance and subsistence working group</rdfs:label>
+    <rdfs:comment>Learn more about the Governance and Subsistence Working Group here: https://alaskasalmonandpeople.org/working-group/governance-and-subsistence/</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:47:12Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000054"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000179">
+    <j.3:definition>A financial institution principally engaged in investing in securites (i.e. a tradable financial asset).</j.3:definition>
+    <rdfs:label xml:lang="en">Investing firm</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-05T20:05:34Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000288">
+    <rdfs:label xml:lang="en">Bert A. Lewis</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:51:45Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000067 rdf:resource="http://purl.dataone.org/odo/SASAP_00000059"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000276">
+    <rdfs:label xml:lang="en">Daniel Schindler</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:43:57Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000397">
+    <j.3:exactMatch rdf:resource="https://schema.org/EducationalOccupationalProgram"/>
+    <rdfs:label xml:lang="en">Academic degree program</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T18:08:49Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <owl:equivalentClass rdf:resource="https://schema.org/EducationalOccupationalProgram"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000264">
+    <rdfs:label xml:lang="en">Liza Mack</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-19T23:55:55Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000056"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000399"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000385">
+    <j.3:altLabel>USF</j.3:altLabel>
+    <owl:sameAs>https://ror.org/032db5x82</owl:sameAs>
+    <rdfs:label xml:lang="en">University of South Florida</rdfs:label>
+    <dc:description>USF's website is accessible at: https://www.usf.edu/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T16:44:47Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000393"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000373">
+    <rdfs:label xml:lang="en">Auke Bay Laboratories</rdfs:label>
+    <dc:description>Auke Bay Laboratories' website is accessible at: https://www.fisheries.noaa.gov/about/auke-bay-laboratories</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T23:09:04Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000379"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A120">
+    <dc:source>https://alaskasalmonandpeople.org/</dc:source>
+    <owl:annotatedTarget>The SASAP project is a deep assessment of the state of knowledge of the biological, sociocultural, economic and governance dimensions of Alaska's salmon and the people who depend upon them. The SASAP project shares this knowledge with Alaska salmon users through comprehensive watershed-level summaries (Regions), focused research on specific salmon issues (Topics), and suppported links to SASAP's free, open-source datasets, accessible through the SASAP Data Portal (https://knb.ecoinformatics.org/portals/SASAP/Data).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000122"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A121">
+    <dc:source>https://wdfw.wa.gov/about</dc:source>
+    <owl:annotatedTarget>A department within the government of Washington which is dedicated to preserving, protecting, and perpetuating the state's fish, wildlife, and ecosystems while providing sustainable fish and wildlife recreational and commercial opportunities.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000047"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000372">
+    <j.3:altLabel>NRC</j.3:altLabel>
+    <rdfs:label xml:lang="en">Natural Resources Consultants, Inc.</rdfs:label>
+    <dc:description>NRC's website is accessible at: https://nrccorp.com/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T23:05:50Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000183"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000033">
+    <dc:description>The Southeast Alaska/Yakutat Region (Region I) consists of Alaska waters between Cape Suckling on the north and Dixon Entrance on the south. Salmon are commercially harvested in Southeast Alaska with purse seines and drift gillnets; in Yakutat with set gillnets; and in both areas with hand and power troll gear. Herring are harvested in winter bait, sac roe, spawn-on-kelp, and bait pound fisheries. Miscellaneous shellfish (sea cucumber, sea urchins, and geoduck clams) are harvested in dive fisheries in the region. The Alaska Department of Fish and Game (ADF&amp;G) has management jurisdiction over all groundfish resources within state waters in Region I. In addition, the State has management authority for Demersal Shelf Rockfish, ling cod, and black and blue rock fish in both state and federal waters. There are several commercially important shellfish species in Southeast Alaska. They include golden and red king crab, Dungeness crab, Tanner crab, and pandalid shrimp.</dc:description>
+    <rdfs:label xml:lang="en">Alaska Department of Fish and Game, Division of Commercial Fisheries, Southeast Region</rdfs:label>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:04:07Z</dc:date>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000028"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <j.3:altLabel>Region I</j.3:altLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <j.3:definition>A department within the government of Alaska and a sub-division of the Alaska Department of Fish and Wildlife, Division of Commercial Fisheries which manages the Southeast Region.</j.3:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000360">
+    <j.3:altLabel>ESPM
+ESPM UC Berkeley</j.3:altLabel>
+    <rdfs:label xml:lang="en">Department of Environmental Science, Policy, and Management</rdfs:label>
+    <dc:description>ESPM's webpage is accessible at: https://ourenvironment.berkeley.edu/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T21:12:55Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000381"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000207"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000045">
+    <j.5:SASAP_00000069 rdf:resource="http://purl.dataone.org/odo/SASAP_00000068"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:05:30Z</dc:date>
+    <j.3:exactMatch>https://ror.org/04k7dar27</j.3:exactMatch>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000025"/>
+    <j.3:definition>A bureau of the United States Department of the Interior whose mission is to work with others to conserve, protect and enhance fish, wildlife and plants and their habitats for the continuing benefit of the American people.</j.3:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <j.3:altLabel>USFWS</j.3:altLabel>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:label xml:lang="en">United States Fish and Wildlife Service</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000057">
+    <j.3:altLabel>Economic working group</j.3:altLabel>
+    <rdfs:label xml:lang="en">Socioeconomic working group</rdfs:label>
+    <rdfs:comment>Learn more about the Socioeconomic Working Group here: https://alaskasalmonandpeople.org/working-group/economic-dimensions-of-salmon-systems/</rdfs:comment>
+    <dc:description>The goals of the Economic working group are to (1) identify important trends in the historical relationships between salmon and salmon users which may have been overlooked, (2) inform and support evidence-based policy aimed at sustainable and equitable decision making, and (3) compile, archive, and share relevant historical socioeconomic data about Alaska's salmon systems.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:47:08Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000054"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000069">
+    <rdfs:label xml:lang="en">hasAffiliate</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T19:11:36Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:range rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdfs:domain rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A122">
+    <j.2:hasDbXref>http://www.adfg.alaska.gov/index.cfm?adfg=divisions.haboverview</j.2:hasDbXref>
+    <owl:annotatedTarget>A department within the government of Alaska which (a) has the specific statutory responsibility of protecting freshwater habitat for anadromous fish and providing free passage for all fish in freshwater bodies, (b) develops management plans and oversees activities (excluding trapping, hunting, fishing, and wildlife viewing) in legislatively designated refuges, critical habitat areas, and sanctuaries known collectively as Special Areas, (c) works with the Division of Sport Fish to update the “Catalog of Waters Important for the Spawning, Rearing, or Migration of Anadromous Fishes,” (d) coordinates the ADF&amp;G review of large and complex projects important to the State, and (e) works closely with the ADNR Division of Forestry to survey State and private forestry operations and evaluate implementation of Alaska’s Forest Resources and Practices Act (FRPA).</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000034"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://rs.tdwg.org/dwc/terms/vernacularName">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A123">
+    <j.2:hasDbXref>http://www.calistaeducation.org/about-us.html</j.2:hasDbXref>
+    <owl:annotatedTarget>The Calista Elders Council was established in 1991 as a non-profit organization representing 1,300 Yup'ik traditional bearers of the Yukon-Kuskokwim Delta in Southwest Alaska. The Calista Elders Council was formed to help protect and preserve the Yup’ik, Cup’ik and Athabascan cultures.
+
+In 2014, after a 20 year history of interacting and working together, the Calista Elders Council, Inc. merged with the former Calista Heritage Foundation to form what is now Calista Education and Culture, Inc.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000368"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A51">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:resource="http://purl.dataone.org/odo/SASAP_00000121"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000178">
+    <j.3:relatedMatch rdf:resource="http://vivoweb.org/ontology/core#ResearchOrganization"/>
+    <j.3:definition>A research institute which is not part of a university, government, hospital or corporation. An independent research institute may have a close relationship with a larger institution such as a university, but is not part of the larger insitution and operates under its own authority.</j.3:definition>
+    <rdfs:label xml:lang="en">Independent research institute</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-05T19:57:33Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000299">
+    <owl:sameAs>https://orcid.org/0000-0002-1234-1297</owl:sameAs>
+    <rdfs:label xml:lang="en">Curry Cunningham</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T16:11:48Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000059"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000379"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000287">
+    <rdfs:label xml:lang="en">Laura Loucks</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:50:50Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000387"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000275">
+    <rdfs:label xml:lang="en">Joe Spaeder</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:40:25Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000347"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000396">
+    <j.3:altLabel>UW EarthLab
+University of Washington EarthLab
+Center for Creative Conservation
+C3</j.3:altLabel>
+    <rdfs:label xml:lang="en">EarthLab</rdfs:label>
+    <rdfs:comment>Since its establishment, the Center has been a member of UW EarthLab—a new environmental institute housing other groups such as the Climate Impacts Group, the Center for Health and the Global Environment, and the Washington Ocean Acidification Center. EarthLab’s inaugural Executive Director, Ben Packard, has been working over the past year to clarify the vision, priorities and strategic outcomes for EarthLab. As this vision has taken shape, it has become clear that the activities of the Center are a key element of EarthLab. Rather than duplicating the efforts of C3 at the EarthLab level, we have decided to integrate the Center for Creative Conservation into EarthLab.</rdfs:comment>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T17:48:10Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000348"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000207"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000263">
+    <rdfs:label xml:lang="en">Jim Fall</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-19T23:54:56Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000056"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000028"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000384">
+    <j.3:altLabel>Auburn</j.3:altLabel>
+    <owl:sameAs>https://ror.org/02v80fc35</owl:sameAs>
+    <rdfs:label xml:lang="en">Auburn University</rdfs:label>
+    <dc:description>Auburn's website is accessible at: https://www.auburn.edu/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T16:43:47Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000393"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A124">
+    <dc:source>https://knb.ecoinformatics.org/portals/SASAP/Regions#copperriver
+https://knb.ecoinformatics.org/view/doi%3A10.5063%2FF1WH2N8W</dc:source>
+    <owl:annotatedTarget>Fewer than 2500 people live permanently in the Copper River region, an area comparable in size to the state of West Virginia. Sockeye salmon are dominant here, given the multiple large lakes available for rearing juvenile salmon. Though less abundant than sockeye, king salmon are deeply important to all salmon-connected people. Kings have declined in number since 2007.
+
+The bounding coordinates for this SASAP region are:
+North: 63.3227 degrees
+South: 59.7112 degrees
+East: -139.6942 degrees
+West: -147.8251 degrees</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000007"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000121">
+    <j.3:exactMatch rdf:resource="https://schema.org/Project"/>
+    <j.3:definition>An enterprise (potentially individual but typically collaborative), planned to achieve a particular aim.</j.3:definition>
+    <rdfs:label xml:lang="en">Project</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-30T20:31:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <owl:equivalentClass rdf:resource="https://schema.org/Project"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000012">
+    <j.3:definition>An inlet of the Bering Sea on the western coast of the State of Alaska, south of the Seward Peninsula. It is about 240 km long and 200 km wide. The Yukon River delta forms a portion of the south shore and water from the Yukon influences this body of water.</j.3:definition>
+    <j.3:closeMatch>http://purl.obolibrary.org/obo/GAZ_00051068</j.3:closeMatch>
+    <rdfs:label xml:lang="en">Norton Sound</rdfs:label>
+    <dc:description>An average of two million pink salmon and 250,000 chum salmon return to the sub-Arctic region of Norton Sound, an area approximately twice the size of Massachusetts.
+
+The bounding coordinates of this SASAP region are:
+North: 65.8544 degrees
+South: 62.8268 degrees
+East: -159.1906 degrees
+West: -171.9762 degrees</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-24T21:28:59Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000001"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000024">
+    <j.3:relatedMatch rdf:resource="http://vivoweb.org/ontology/core#GovernmentAgency"/>
+    <j.3:relatedMatch rdf:resource="http://purl.bioontology.org/ontology/MESH/D013219"/>
+    <j.3:definition>A permanent or semi-permanent state govenrment organization which is responsible for the oversight and administration of specific functions.</j.3:definition>
+    <rdfs:label xml:lang="en">State government department, division, or agency</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:01:09Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000036">
+    <j.3:definition>A department within the government of Alaska with a mission to scientifically gather, quantify, evaluate, and report information about customary and traditional uses of Alaska's fish and wildlife resources.</j.3:definition>
+    <rdfs:label xml:lang="en">Alaska Department of Fish and Game, Division of Subsistence</rdfs:label>
+    <dc:description>The Subsistence Section provides the following core services: (a) Compile and analyze existing data; conduct research to gather information on the role of hunting and fishing by Alaskans for customary and traditional uses, (b) Disseminate current subsistence use information to the public; appropriate agencies and organizations; and fisheries and wildlife management divisions, (c) Assist the Board of Fisheries, the Board of Game, and the Joint Board of Fisheries and Game to evaluate customary and traditional uses of Alaska's fish and wildlife resources and amounts reasonably necessary for subsistence uses (ANS) of those resources, and (d) Assist fisheries and wildlife managers in preparing management plans to ensure information on customary and traditional uses and fish and wildlife harvests is incorporated.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:04:20Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000028"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000048">
+    <j.3:definition>An entity created by treaty, involving two or more nations, to work in good faith, on issues of common interest.</j.3:definition>
+    <rdfs:label xml:lang="en">Intergovernmental organization</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:06:04Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/creator">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000278">
+    <rdfs:label xml:lang="en">Bill Bechtol</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:45:26Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000349"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000399">
+    <rdfs:label xml:lang="en">Indigenous Studies Program</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T18:09:34Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000112"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000398"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000266">
+    <rdfs:label xml:lang="en">Rob Sanderson Jr.</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-19T23:58:18Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000056"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000343"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000387">
+    <j.3:altLabel>CBT</j.3:altLabel>
+    <rdfs:label xml:lang="en">Clayoquot Biosphere Trust</rdfs:label>
+    <dc:description>CBT's website is accessible at: https://clayoquotbiosphere.org/about-us/overview</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T17:21:37Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000386"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000254">
+    <rdfs:label xml:lang="en">isSupportingResearcherOf</rdfs:label>
+    <dc:description>In addition to a lead researcher, some SASAP working groups have an additional affiliated researcher(s) to assist in the research efforts. The 'isSupportingResearcherOf' object property connects supporting researchers to their respective working groups.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-19T21:19:32Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:range rdf:nodeID="A44"/>
+    <rdfs:domain rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <owl:inverseOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000255"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000375">
+    <j.3:altLabel>Mountains to Sea</j.3:altLabel>
+    <rdfs:label xml:lang="en">Kenai Mountains to Sea</rdfs:label>
+    <dc:description>Kenai Mountains to Sea's website is accessible at: https://kenaiwatershed.org/science-in-action/mountains-to-sea/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T23:24:55Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000374"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000363">
+    <rdfs:label xml:lang="en">Akiak Native Community</rdfs:label>
+    <dc:description>The Akiak Native Community's website is accessible at: https://akiaknativecommunity.org/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T21:31:20Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000341"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000351">
+    <j.3:altLabel>NOAA</j.3:altLabel>
+    <owl:sameAs>https://ror.org/02z5nhe81</owl:sameAs>
+    <rdfs:label xml:lang="en">National Oceanic and Atmospheric Administration</rdfs:label>
+    <dc:description>NOAA's website is accessible at: https://www.noaa.gov/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T20:10:56Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000025"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000350">
+    <j.3:altLabel>UW</j.3:altLabel>
+    <owl:sameAs>https://ror.org/01y2jtd41</owl:sameAs>
+    <rdfs:label xml:lang="en">University of Wisconsin-Madison</rdfs:label>
+    <dc:description>UW's website is accessible at: https://www.wisc.edu/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T20:08:29Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000393"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000011">
+    <j.3:definition>A sound of the Gulf of Alaska on the south coast of the State of Alaska. It is located on the east side of the Kenai Peninsula.</j.3:definition>
+    <j.3:closeMatch>http://purl.obolibrary.org/obo/GAZ_00051075</j.3:closeMatch>
+    <j.3:altLabel>PWS</j.3:altLabel>
+    <rdfs:label xml:lang="en">Prince William Sound</rdfs:label>
+    <dc:description>Prince William Sound is a region of rain, icefields, and glaciers. Only two (Whittier and Valdez) of Prince William Sound’s largest human communities are connected via road. The terminus of the Alaska oil pipeline ends in this region and results in a fairly high footprint of human activity in a relatively small region. Pink salmon, chum salmon, and sockeye salmon fisheries are current mainstays of local communities with hatchery enhancement of these species (particularly pink salmon) a fundamental dynamic in the region.
+
+The bounding coordinates of this SASAP region are:
+North: 61.5189  degrees
+South: 59.357  degrees
+East: -145.1013  degrees
+West: -149.1761  degrees</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-24T21:28:55Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000001"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000035">
+    <j.3:definition>A department within the government of Alaska with a mission to protect and improve the state's sport fishery resources.</j.3:definition>
+    <rdfs:label xml:lang="en">Alaska Department of Fish and Game, Division of Sport Fish</rdfs:label>
+    <dc:description>The Division of Sport Fisheries provides the following core services: (a) fisheries management, (b) fisheries research, (c) fisheries enhancement, (d) protection and restoration of fish habitats for the ebefit of fish and sport anglers, (e) communication and outreach, and (f) providing leadership and administrative support for the Division's core functions.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:04:16Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.1:memberOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000028"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000047">
+    <j.3:definition>A department within the government of Washington which is dedicated to preserving, protecting, and perpetuating the state's fish, wildlife, and ecosystems while providing sustainable fish and wildlife recreational and commercial opportunities.</j.3:definition>
+    <j.3:altLabel>WDFW</j.3:altLabel>
+    <owl:sameAs>https://ror.org/03dnb3013</owl:sameAs>
+    <rdfs:label xml:lang="en">Washington Department of Fish and Wildlife</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:05:41Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000409 rdf:resource="http://purl.dataone.org/odo/SASAP_00000102"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000024"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000059">
+    <rdfs:label xml:lang="en">Salmon size working group</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-25T18:47:18Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000054"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://usefulinc.com/ns/doap#GitRepository">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A125">
+    <dc:source>http://en.wikipedia.org/wiki/Cook_Inlet
+https://www.wikidata.org/wiki/Q5166925</dc:source>
+    <owl:annotatedTarget>A large estuary stretching 180 miles from the Gulf of Alaska to Anchorage in south-central Alaska. It separates the Kenai Peninsula from mainland Alaska and branches into the Knik Arm and Turnagain Arm at its northern end, almost surrounding Anchorage. The watershed covers about 100,000 km2 of southern Alaska, east of the Aleutian Range and south of the Alaska Range, receiving water from its tributaries the Knik River, the Little Susitna River, and the Susitna and Matanuska rivers. The watershed includes the drainage areas of Mount McKinley. Within the watershed there are several national parks and four historically active volcanoes.</owl:annotatedTarget>
+    <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+    <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/SASAP_00000006"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Axiom"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000289">
+    <owl:sameAs>https://orcid.org/0000-0001-6102-1110</owl:sameAs>
+    <rdfs:label xml:lang="en">Marissa L. Baskett</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:53:13Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000059"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000359"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000277">
+    <rdfs:label xml:lang="en">Milo Adkison</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T15:44:32Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000061"/>
+    <j.5:SASAP_00000254 rdf:resource="http://purl.dataone.org/odo/SASAP_00000060"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000113"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000398">
+    <rdfs:label xml:lang="en">Graduate degree program</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T18:09:16Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000397"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000265">
+    <rdfs:label xml:lang="en">Julie Raymond-Yakoubian</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-19T23:57:10Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000063"/>
+    <j.5:SASAP_00000257 rdf:resource="http://purl.dataone.org/odo/SASAP_00000056"/>
+    <j.5:SASAP_00000066 rdf:resource="http://purl.dataone.org/odo/SASAP_00000339"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000064"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000386">
+    <rdfs:label xml:lang="en">Charity</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-21T17:14:16Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000374">
+    <rdfs:label xml:lang="en">Federal/non-federal partnerships and programs</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T23:24:11Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SASAP_00000098"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SASAP_00000362">
+    <j.3:definition>Old Harbor Native Corporation (OHNC) was established in 1971 under the terms of the Alaska Native Claims Settlement Act (ANCSA).
+
+OHNC’s mission is to preserve and protect the culture, values and traditions of its community, shareholders and descendants; and to work together to create economic and educational opportunities while promoting self-determination and pride.</j.3:definition>
+    <rdfs:label xml:lang="en">Old Harbor Native Corporation</rdfs:label>
+    <dc:description>OHNC's website is accessible at: https://www.oldharbornativecorp.com/</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-20T21:29:40Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://purl.dataone.org/odo/SASAP_00000097"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/src/main/resources/ontologies/SENSO.owl
+++ b/src/main/resources/ontologies/SENSO.owl
@@ -1,0 +1,126 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:envo="http://purl.obolibrary.org/obo/envo#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns="http://purl.dataone.org/odo/SENSO_"
+    xmlns:odo="http://purl.dataone.org/odo/"
+    xmlns:terms="http://purl.org/dc/terms/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:obo="http://purl.obolibrary.org/obo/"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#" > 
+  <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000119">
+    <rdfs:label xml:lang="en">definition source</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-11-04T19:47:37Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#altLabel">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.geneontology.org/formats/oboInOwl#shorthand">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SENSO_">
+    <terms:contributor rdf:resource="https://orcid.org/0000-0003-0632-7576"/>
+    <terms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-28</terms:created>
+    <terms:creator rdf:resource="https://orcid.org/0000-0003-0077-4738"/>
+    <terms:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
+    <owl:versionIRI rdf:resource="http://purl.dataone.org/odo/SENSO/0.1.0"/>
+    <terms:title xml:lang="en">Sensitive Data Ontology (SENSO)</terms:title>
+    <owl:versionInfo>Version 0.1.0</owl:versionInfo>
+    <terms:contributor rdf:resource="https://orcid.org/0000-0002-0381-3766"/>
+    <terms:description xml:lang="en">Ontology to support sensitive data annotation of datasets housed at the Arctic Data Center (https://arcticdata.io)</terms:description>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/creator">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/description">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/date">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SENSO_00000002">
+    <rdfs:label xml:lang="en">Non-sensitive data</rdfs:label>
+    <dc:description xml:lang="en">None of the data includes sensitive or protected information.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-28</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0077-4738"/>
+    <obo:IAO_0000115 xml:lang="en">Non-sensitive data</obo:IAO_0000115>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SENSO_00000001"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SENSO_00000001">
+    <rdfs:label xml:lang="en">Data Sensitivity Category</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-28</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0077-4738"/>
+    <obo:IAO_0000115>Data sensitivity categories assign a level of sensitivity for datasets and provide guidelines for acceptable distribution and use.</obo:IAO_0000115>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/description">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2001/XMLSchema#date">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Datatype"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.geneontology.org/formats/oboInOwl#id">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#comment">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/creator">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/contributor">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/created">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
+    <rdfs:label xml:lang="en">definition</rdfs:label>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-09-28T19:46:54Z</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0002-5300-3075"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SENSO_00000005">
+    <rdfs:label xml:lang="en">data sensitivity</rdfs:label>
+    <terms:creator rdf:resource="https://orcid.org/0000-0002-0381-3766"/>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dc:date>
+    <obo:IAO_0000115 xml:lang="en">the sensitivity of the given data</obo:IAO_0000115>
+    <rdfs:range rdf:resource="http://purl.dataone.org/odo/SENSO_00000001"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/license">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SENSO_00000004">
+    <rdfs:label xml:lang="en">Sensitive data</rdfs:label>
+    <dc:description xml:lang="en">The data contains human subjects data or other sensitive data. Release of the data could cause harm or violate statutes, and must remain confidential following restrictions from an Institutional Review Board (IRB) or similar body.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-28</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0077-4738"/>
+    <obo:IAO_0000115 xml:lang="en">Some or all data is sensitive and should not be distributed</obo:IAO_0000115>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SENSO_00000001"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.dataone.org/odo/SENSO_00000003">
+    <rdfs:label xml:lang="en">De-identified data</rdfs:label>
+    <dc:description xml:lang="en">Sensitive data has been de-identified, anonymized, aggregated, or summarized to remove sensitivities and enable safe data distribution. Examples include ensuring that human subjects data, protected species data, archaeological site locations and personally identifiable information have been properly anonymized, aggregated and summarized.</dc:description>
+    <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-28</dc:date>
+    <dc:creator rdf:resource="http://orcid.org/0000-0003-0077-4738"/>
+    <obo:IAO_0000115 xml:lang="en">Some or all data is sensitive but has been made safe for open distribution</obo:IAO_0000115>
+    <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/SENSO_00000001"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000118">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/title">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/src/test/java/org/dataone/cn/indexer/annotation/EmlAnnotationSubprocessorTest.java
+++ b/src/test/java/org/dataone/cn/indexer/annotation/EmlAnnotationSubprocessorTest.java
@@ -60,17 +60,26 @@ public class EmlAnnotationSubprocessorTest {
             // Set up expected concepts and assert
             List<String> expectedConcepts = new ArrayList<String>();
 
-            expectedConcepts.add("http://purl.dataone.org/odo/ECSO_00000512");
+            expectedConcepts.add("http://www.w3.org/2002/07/owl#FunctionalProperty");
             expectedConcepts.add("http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#MeasurementType");
+            expectedConcepts.add("http://purl.dataone.org/odo/ARCRC_00000040");
             expectedConcepts.add("http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#hasUnit");
-            expectedConcepts.add("http://purl.dataone.org/odo/ECSO_00001102");
-            expectedConcepts.add("http://purl.dataone.org/odo/ECSO_00001243");
+            expectedConcepts.add("http://www.w3.org/2000/01/rdf-schema#Class");
             expectedConcepts.add("http://purl.dataone.org/odo/ECSO_00000629");
+            expectedConcepts.add("http://purl.dataone.org/odo/ARCRC_00000048");
             expectedConcepts.add("http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#containsMeasurementsOfType");
+            expectedConcepts.add("http://www.w3.org/2002/07/owl#Class");
             expectedConcepts.add("http://purl.dataone.org/odo/ECSO_00000518");
-            expectedConcepts.add("http://www.w3.org/2000/01/rdf-schema#Resource");
             expectedConcepts.add("http://purl.dataone.org/odo/ECSO_00000516");
             expectedConcepts.add("http://purl.obolibrary.org/obo/UO_0000301");
+            expectedConcepts.add("http://purl.dataone.org/odo/ECSO_00000512");
+            expectedConcepts.add("http://purl.dataone.org/odo/ARCRC_00000500");
+            expectedConcepts.add("http://purl.dataone.org/odo/ECSO_00001102");
+            expectedConcepts.add("http://www.w3.org/1999/02/22-rdf-syntax-ns#Property");
+            expectedConcepts.add("http://purl.dataone.org/odo/ECSO_00001243");
+            expectedConcepts.add("http://www.w3.org/2002/07/owl#ObjectProperty");
+            expectedConcepts.add("http://www.w3.org/2002/07/owl#NamedIndividual");
+            expectedConcepts.add("http://www.w3.org/2000/01/rdf-schema#Resource");
 
             assertEquals(1, solrDocs.size());
             assertEquals(expectedConcepts, expandedConcepts);

--- a/src/test/java/org/dataone/cn/indexer/annotation/OntologyModelServiceTest.java
+++ b/src/test/java/org/dataone/cn/indexer/annotation/OntologyModelServiceTest.java
@@ -217,4 +217,144 @@ public class OntologyModelServiceTest {
 			fail(e.getMessage());
 		}
 	}
+
+	@Test
+	public void testADCADExpansion() {
+		try {
+			Map<String, Set<String>> concepts = OntologyModelService.getInstance().expandConcepts("https://purl.dataone.org/odo/ADCAD_00034");
+
+
+			// Assert on Solr fields returend
+			Set<String> fields = new HashSet<String>();
+			fields.add("annotation_property_uri");
+			fields.add("annotation_value_uri");
+			assertEquals(concepts.keySet(), fields);
+
+			// Assert on Solr field values returned
+			Set<String> values = new HashSet<String>();
+			values.add("https://purl.dataone.org/odo/ADCAD_00034");
+			values.add("https://purl.dataone.org/odo/ADCAD_00067");
+			values.add("https://purl.dataone.org/odo/ADCAD_00033");
+			values.add("https://purl.dataone.org/odo/ADCAD_00000");
+			values.add("http://www.w3.org/2000/01/rdf-schema#Class");
+			values.add("http://localhost/plosthes.2017-1#2863");
+			values.add("http://www.w3.org/2002/07/owl#Class");
+			values.add("https://www.wikidata.org/wiki/Q2329");
+			values.add("http://www.w3.org/2000/01/rdf-schema#Resource");
+
+			assertEquals(values, concepts.get("annotation_value_uri"));
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testSALMONExpansion() {
+		try {
+			Map<String, Set<String>> concepts = OntologyModelService.getInstance().expandConcepts("https://purl.dataone.org/odo/MOSAIC_00000041");
+
+
+			// Assert on Solr fields returend
+			Set<String> fields = new HashSet<String>();
+			fields.add("annotation_property_uri");
+			fields.add("annotation_value_uri");
+			assertEquals(concepts.keySet(), fields);
+
+			// Assert on Solr field values returned
+			Set<String> values = new HashSet<String>();
+			values.add("https://purl.dataone.org/odo/MOSAIC_00000041");
+			values.add("http://www.w3.org/2000/01/rdf-schema#Class");
+			values.add("http://www.w3.org/2002/07/owl#Class");
+			values.add("https://purl.dataone.org/odo/MOSAIC_00012000");
+			values.add("http://www.w3.org/2000/01/rdf-schema#Resource");
+
+			assertEquals(values, concepts.get("annotation_value_uri"));
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testSALMONAlignmentExpansion() {
+		try {
+			Map<String, Set<String>> concepts = OntologyModelService.getInstance().expandConcepts("http://purl.dataone.org/odo/salmon_000529");
+
+			// Assert on Solr fields returend
+			Set<String> fields = new HashSet<String>();
+			fields.add("annotation_property_uri");
+			fields.add("annotation_value_uri");
+			assertEquals(concepts.keySet(), fields);
+
+			// Assert on Solr field values returned
+			Set<String> values = new HashSet<String>();
+			values.add("http://purl.dataone.org/odo/SALMON_00000672");
+			values.add("http://purl.dataone.org/odo/SALMON_00000572");
+			values.add("http://purl.dataone.org/odo/SALMON_00000528");
+			values.add("http://www.w3.org/2002/07/owl#Class");
+			values.add("http://purl.dataone.org/odo/salmon_000529");
+			values.add("http://purl.dataone.org/odo/SALMON_00000529");
+
+			assertEquals(values, concepts.get("annotation_value_uri"));
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testSASAPExpansion() {
+		try {
+			Map<String, Set<String>> concepts = OntologyModelService.getInstance().expandConcepts("http://purl.dataone.org/odo/SASAP_00000393");
+
+
+			// Assert on Solr fields returend
+			Set<String> fields = new HashSet<String>();
+			fields.add("annotation_property_uri");
+			fields.add("annotation_value_uri");
+			assertEquals(concepts.keySet(), fields);
+
+			// Assert on Solr field values returned
+			Set<String> values = new HashSet<String>();
+			values.add("http://purl.dataone.org/odo/SASAP_00000098");
+			values.add("http://purl.dataone.org/odo/SASAP_00000174");
+			values.add("http://www.w3.org/2000/01/rdf-schema#Class");
+			values.add("http://purl.dataone.org/odo/SASAP_00000393");
+			values.add("http://www.w3.org/2002/07/owl#Class");
+			values.add("http://www.w3.org/2000/01/rdf-schema#Resource");
+
+			assertEquals(values, concepts.get("annotation_value_uri"));
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testSENSOExpansion() {
+		try {
+			Map<String, Set<String>> concepts = OntologyModelService.getInstance().expandConcepts("http://purl.dataone.org/odo/SENSO_00000002");
+
+
+			// Assert on Solr fields returend
+			Set<String> fields = new HashSet<String>();
+			fields.add("annotation_property_uri");
+			fields.add("annotation_value_uri");
+			assertEquals(concepts.keySet(), fields);
+
+			// Assert on Solr field values returned
+			Set<String> values = new HashSet<String>();
+			values.add("http://purl.dataone.org/odo/SENSO_00000002");
+			values.add("http://www.w3.org/2000/01/rdf-schema#Class");
+			values.add("http://purl.dataone.org/odo/SENSO_00000001");
+			values.add("http://www.w3.org/2002/07/owl#Class");
+			values.add("http://www.w3.org/2000/01/rdf-schema#Resource");
+
+			assertEquals(values, concepts.get("annotation_value_uri"));
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
 }

--- a/src/test/java/org/dataone/cn/indexer/annotation/OntologyModelServiceTest.java
+++ b/src/test/java/org/dataone/cn/indexer/annotation/OntologyModelServiceTest.java
@@ -200,4 +200,21 @@ public class OntologyModelServiceTest {
 			fail(e.getMessage());
 		}
 	}
+
+	@Test
+	public void testEquivalentPropertyExpansion() {
+		try {
+			Map<String, Set<String>> concepts = OntologyModelService.getInstance().expandConcepts("https://purl.dataone.org/odo/MOSAIC_00002250");
+
+			Set<String> values = new HashSet<String>();
+			values.add("http://www.w3.org/ns/ssn/deployedSystem");
+			values.add("https://purl.dataone.org/odo/MOSAIC_00002250");
+
+			assertEquals(values, concepts.get("annotation_property_uri"));
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
 }

--- a/src/test/java/org/dataone/cn/indexer/annotation/OntologyModelServiceTest.java
+++ b/src/test/java/org/dataone/cn/indexer/annotation/OntologyModelServiceTest.java
@@ -67,6 +67,8 @@ public class OntologyModelServiceTest {
 			values.add("http://purl.dataone.org/odo/ECSO_00000514");
 			values.add("http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#MeasurementType");
 			values.add("http://www.w3.org/2000/01/rdf-schema#Resource");
+			values.add("http://www.w3.org/2000/01/rdf-schema#Class");
+			values.add("http://www.w3.org/2002/07/owl#Class");
 
 			assertEquals(values, concepts.get("annotation_value_uri"));
 		} catch (Exception e) {
@@ -87,6 +89,111 @@ public class OntologyModelServiceTest {
 			values.add("http://purl.obolibrary.org/obo/RO_0000056");
 
 			assertEquals(values, concepts.get("annotation_property_uri"));
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testMOSAiCExpansion() {
+		try {
+			Map<String, Set<String>> concepts = OntologyModelService.getInstance().expandConcepts("https://purl.dataone.org/odo/MOSAIC_00000865");
+
+			Set<String> values = new HashSet<String>();
+			values.add("https://purl.dataone.org/odo/MOSAIC_00000865");
+			values.add("https://purl.dataone.org/odo/MOSAIC_00000036");
+			values.add("https://purl.dataone.org/odo/MOSAIC_00012000");
+			values.add("http://www.w3.org/2000/01/rdf-schema#Resource");
+			values.add("http://www.w3.org/2000/01/rdf-schema#Class");
+			values.add("http://www.w3.org/2002/07/owl#Class");
+
+			assertEquals(values, concepts.get("annotation_value_uri"));
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testMOSAiCSameAsExpansion() {
+		try {
+			Map<String, Set<String>> concepts = OntologyModelService.getInstance().expandConcepts("https://purl.dataone.org/odo/MOSAIC_00000225");
+
+			Set<String> values = new HashSet<String>();
+			values.add("https://purl.dataone.org/odo/MOSAIC_00000022"); // Project
+			values.add("https://purl.dataone.org/odo/MOSAIC_00000225"); // MOSAiC
+			values.add("https://purl.dataone.org/odo/MOSAIC_00000226"); // Multidisciplinary drifting Observatory for the Study of Arctic Climate (sameAs)
+			values.add("https://purl.dataone.org/odo/MOSAIC_00000023"); // MOSAiC20192020 (sameAs)
+			values.add("http://www.w3.org/2002/07/owl#NamedIndividual");
+			values.add("http://www.w3.org/2000/01/rdf-schema#Resource");
+
+			assertEquals(values, concepts.get("annotation_value_uri"));
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testARCRCExpansion() {
+		try {
+			Map<String, Set<String>> concepts = OntologyModelService.getInstance().expandConcepts("http://purl.dataone.org/odo/ARCRC_00000051");
+
+			Set<String> values = new HashSet<String>();
+			/**
+			 * Add values for ARCRC:SnowDepth and its supertypes:
+			 *
+			 *   SnowDepth -> Snow Key Variable Arctic Key Variable -> Arctic Report Card Component
+			 */
+			values.add("http://purl.dataone.org/odo/ARCRC_00000051"); // ARCRC:SnowDepth
+			values.add("http://purl.dataone.org/odo/ARCRC_00000502"); // ARCRC:SnowKeyVariable
+			values.add("http://purl.dataone.org/odo/ARCRC_00000040"); // ARCRC:KeyVariable
+			values.add("http://purl.dataone.org/odo/ARCRC_00000500"); // ARCRC:ArcticReportCardComponent
+
+
+			/**
+			 * Add values for ARCRC:SnowDepth's equivalentClass of ECSO:SnowDepth and its supertypes:
+			 *
+			 *   SnowDepth -> Water Depth -> Depth -> linearMeasurementType -> Measurement Type
+			 */
+			values.add("http://purl.dataone.org/odo/ECSO_00001205"); // ECSO:SnowDepth
+			values.add("http://purl.dataone.org/odo/ECSO_00000553"); // ECSO:linearMeasurementType
+			values.add("http://purl.dataone.org/odo/ECSO_00001203"); // ECSO:WaterDepth
+			values.add("http://purl.dataone.org/odo/ECSO_00001250"); // ECSO:Depth
+			values.add("http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#MeasurementType");
+
+			// Values for high level stuff
+			values.add("http://www.w3.org/2000/01/rdf-schema#Resource");
+			values.add("http://www.w3.org/2000/01/rdf-schema#Class");
+			values.add("http://www.w3.org/2002/07/owl#Class");
+			values.add("http://www.w3.org/2002/07/owl#NamedIndividual");
+
+			assertEquals(values, concepts.get("annotation_value_uri"));
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testNamedIndividualExpansion() {
+		try {
+			Map<String, Set<String>> concepts = OntologyModelService.getInstance().expandConcepts("http://purl.dataone.org/odo/ARCRC_00000507");
+
+			Set<String> values = new HashSet<String>();
+			values.add("http://purl.dataone.org/odo/ARCRC_00000507"); // ARCRC:Greenland itself
+			values.add("http://www.w3.org/2002/07/owl#NamedIndividual"); // the type of ARCRC:Greenland
+			values.add("http://purl.dataone.org/odo/ARCRC_00000505"); // ARCRC:GeographicNamedPlace (type of ARCRC:Greenland)
+			values.add("http://purl.dataone.org/odo/ARCRC_00000506"); // ARCRC:Place (supertype of GeographicNamedPlace)
+			values.add("http://purl.dataone.org/odo/ARCRC_00000500"); // ARCRC:ArcticReportCardComponent
+			values.add("http://purl.obolibrary.org/obo/GAZ_00001507"); // sameAs
+
+			assertEquals(values, concepts.get("annotation_value_uri"));
 		} catch (Exception e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();

--- a/src/test/java/org/dataone/cn/indexer/annotation/SolrFieldEmlAnnotationTest.java
+++ b/src/test/java/org/dataone/cn/indexer/annotation/SolrFieldEmlAnnotationTest.java
@@ -65,18 +65,26 @@ public class SolrFieldEmlAnnotationTest extends BaseSolrFieldXPathTest {
     public void setUp() throws Exception {
         // annotations should include the superclass[es]
         annotationExpected.put("sem_annotation",
-            "http://purl.dataone.org/odo/ECSO_00000512" + "||" +
+            "http://www.w3.org/2002/07/owl#FunctionalProperty" + "||" +
             "http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#MeasurementType" + "||" +
-            "http://purl.dataone.org/odo/ECSO_00001102" + "||" +
-            "http://purl.dataone.org/odo/ECSO_00001243" + "||" +
+            "http://purl.dataone.org/odo/ARCRC_00000040" + "||" +
+            "http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#hasUnit" + "||" +
+            "http://www.w3.org/2000/01/rdf-schema#Class" + "||" +
             "http://purl.dataone.org/odo/ECSO_00000629" + "||" +
+            "http://purl.dataone.org/odo/ARCRC_00000048" + "||" +
+            "http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#containsMeasurementsOfType" + "||" +
+            "http://www.w3.org/2002/07/owl#Class" + "||" +
             "http://purl.dataone.org/odo/ECSO_00000518" + "||" +
-            "http://www.w3.org/2000/01/rdf-schema#Resource" + "||" +
             "http://purl.dataone.org/odo/ECSO_00000516" + "||" +
             "http://purl.obolibrary.org/obo/UO_0000301" + "||" +
-            "http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#hasUnit" + "||" +
-            "http://purl.dataone.org/odo/ECSO_00000629" + "||" +
-            "http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#containsMeasurementsOfType");
+            "http://purl.dataone.org/odo/ECSO_00000512" + "||" +
+            "http://purl.dataone.org/odo/ARCRC_00000500" + "||" +
+            "http://purl.dataone.org/odo/ECSO_00001102" + "||" +
+            "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property" + "||" +
+            "http://purl.dataone.org/odo/ECSO_00001243" + "||" +
+            "http://www.w3.org/2002/07/owl#ObjectProperty" + "||" +
+            "http://www.w3.org/2002/07/owl#NamedIndividual" + "||" +
+            "http://www.w3.org/2000/01/rdf-schema#Resource");
     }
 
     protected boolean compareFields(HashMap<String, String> expected, InputStream document,


### PR DESCRIPTION
Hey @taojing2002, this adds indexing support for two new ontologies we've developed over on https://github.com/DataONEorg/sem-prov-ontologies for DataONEorg/d1_cn_index_processor#29 and also tweaks some of the indexing logic described in DataONEorg/dataone-indexer#3.

The PR includes automated tests and I've done a fair bit of manual testing so this doesn't need an in-depth review, though I'd appreciate you taking a quick look.

Closes DataONEorg/d1_cn_index_processor#29  and DataONEorg/dataone-indexer#3.
